### PR TITLE
Improving error logging  

### DIFF
--- a/q.js
+++ b/q.js
@@ -338,7 +338,7 @@ function forward(promise /*, op, resolved, ... */) {
         try {
             promise.emit.apply(promise, args);
         } catch (exception) {
-            print(exception);
+            print(exception.stack || exception);
         }
     });
 }


### PR DESCRIPTION
Just an error message in console does not helps match to figure out what exactly caused error. Printing stack (which BTW includes message) makes error much more discoverable.
