### PR TITLE
export Q in browser context

### DIFF
--- a/lib/q.js
+++ b/lib/q.js
@@ -553,6 +553,6 @@ function forward(promise /* ... */) {
 })(
     typeof exports !== "undefined" ?
     exports :
-    this["/q"] = {}
+    this["Q"] = {}
 );
 


### PR DESCRIPTION
This lib exports `window["\q"]` which doesn't seem like a useful name to me, especially since the README is using `Q`, which is very confusing to a newbie.

The change made in the attached patch is reverting a change made in 559e68d8a761cd7b49730b59f116b4b9225da53e but there was no reason provided in 559e68d8a761cd7b49730b59f116b4b9225da53e for the change..
