### PR TITLE
Add support for calling define to set up the q module in environments that have a usable define() call.

### DIFF
--- a/q.js
+++ b/q.js
@@ -23,8 +23,10 @@
     // replaced with a single-character.
 
     // RequireJS
-    if (typeof define === "function") {
-        define(definition);
+    if (typeof define === "function" && define.amd) {
+        define(function (require, exports) {
+            definition(require, exports);
+        });
     // CommonJS
     } else if (typeof exports === "object") {
         definition(require, exports);


### PR DESCRIPTION
This pull request tries to call define() in a way that works for AMD loaders and in a way that allows for the module to be optimized into build layers for use in an AMD loader. We are using q for a project at work that uses an AMD loader, and this change should also allow q to work in Dojo 1.7+ projects, although I have not tested it with Dojo yet.

I completely understand if you prefer to not pursue this kind of functionality, no problem if you just want to close this pull request.

If you would like to consider it, I can do changes to match style where I missed it, and if you want to clue me into running the tests, I can make sure I did not break anything. My initial stab at trying "node test/all.js" did not work using the repo source ("cannot find module 'q'"). I could be missing something very basic though, I'm still new to stock Node testing. I will also make sure it works with the Dojo AMD loader. It works with requirejs in my work project.
