### PR TITLE
Define

### DIFF
--- a/q.js
+++ b/q.js
@@ -23,8 +23,10 @@
     // replaced with a single-character.
 
     // RequireJS
-    if (typeof define === "function") {
-        define(definition);
+    if (typeof define === "function" && define.amd) {
+        define(function (require, exports) {
+            definition(require, exports);
+        });
     // CommonJS
     } else if (typeof exports === "object") {
         definition(require, exports);


### PR DESCRIPTION
I added a function wrapper to allow the optimizer to properly identify a loader define call and insertion of standard CommonJS dependencies. This also allows insertion of the module ID for when combining with other modules. I'm open to other ideas though if you think the impact is too large or should not be required.

The use of "require" and "exports" in that function wrapper can be shortened to smaller names if smaller source code impact is desired.

I also added a define.amd check to make sure it is an loader's define call. That could be removed for space concerns. It increases the risk of possibly calling a define() function that may not be a loader call, but you would know best if that risk is manageable for the Q audience.

Hmm, I may have goofed in this pull request workflow, maybe I should have created a define2 branch that uses your define branch as the base, so feel free to resolve any code changes how you see fit, or give me guidance on how I should do it next time.
