### PR TITLE
Fixing `Q.all` in the case of an empty array. GH-32

### DIFF
--- a/q.js
+++ b/q.js
@@ -729,7 +729,7 @@ function all(promises) {
     return when(promises, function (promises) {
         var countDown = promises.length;
         if (countDown === 0)
-            return ref(values);
+            return ref(promises);
         var deferred = defer();
         reduce.call(promises, function (undefined, promise, index) {
             when(promise, function (value) {


### PR DESCRIPTION
When an empty array was passed to `Q.all`, it would throw a `ReferenceError` since it was trying to use the `values` variable from an older revision instead of the `promises` array from the current one.
