### PR TITLE
Add support for cancelation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,22 @@
  - WARNING: The deprecated ``node`` export will be removed.
    Use ``nbind``.
 
+## Next minor
+
+ - Added ``promise.cancel()``, ``Q.defer(canceler)``
+   argument and ``promise.cancelable(canceler)`` interface
+   for making it possible to support per-promise
+   unregistration of interest in a promise resolution.
+   Cancelation is ignored by default.  Cancelation does not
+   reject the promise.  A cancelable promise should be
+   constructed for each independent receiver of a promise to
+   guarantee that cancelation is not observable and will not
+   interfere with other receivers of a promise.
+   WARNING: Because cancelation must be handled with care in
+   security-concious situations, this feature may be removed
+   for the good of us all in a future major version.  Be
+   excellent to each other.
+
 ## 0.8.3
 
  - Added ``isFulfilled``, ``isRejected``, and ``isResolved``

--- a/test/all.js
+++ b/test/all.js
@@ -11,6 +11,7 @@ exports['test spread'] = require('./spread');
 exports['test allResolved'] = require("./all-resolved");
 exports['test node'] = require('./node');
 exports['test bind'] = require('./bind');
+exports['test cancel'] = require("./cancel");
 
 exports['test GH issue 9'] = require('./issue/9');
 exports['test GH issue 22'] = require('./issue/22');

--- a/test/cancel.js
+++ b/test/cancel.js
@@ -1,0 +1,111 @@
+'use strict';
+
+var Q = require('../q');
+
+function fixture(canceled) {
+    var deferred = Q.defer();
+    var handle = setTimeout(deferred.resolve, 500);
+    return deferred.promise
+    .cancelable(function () {
+        canceled();
+        clearTimeout(handle);
+    });
+}
+
+function fixture2(canceled) {
+    var deferred = Q.defer(function () {
+        canceled();
+        clearTimeout(handle);
+    });
+    var handle = setTimeout(deferred.resolve, 500);
+    return deferred.promise;
+}
+
+exports['test non-cancelable canceled'] = function (assert, done) {
+    var deferred = Q.defer();
+    deferred.promise.cancel();
+    deferred.resolve();
+    deferred.promise
+    .timeout(100)
+    .then(function () {
+        assert.ok(true, 'should be fulfilled despite cancelation');
+    }, function () {
+        assert.ok(false, 'should not time out');
+    })
+    .finally(done)
+};
+
+exports['test cancelable not canceled'] = function (assert, done) {
+    fixture(function onCancel() {
+        assert.ok(false, 'should not be canceled');
+    })
+    .then(function fulfilled() {
+        assert.ok(true, 'should be fulfilled');
+    }, function rejected() {
+        assert.ok(false, 'should not be rejected');
+    })
+    .timeout(1000)
+    .fail(function (exception) {
+        assert.ok(false, exception.message);
+    })
+    .finally(done)
+    .end()
+};
+
+exports['test cancelable canceled'] = function (assert, done) {
+    var canceled;
+    var promise = fixture(function onCancel() {
+        canceled = true;
+    })
+    promise.cancel();
+    promise.then(function () {
+        assert.ok(false, 'should not be fulfilled');
+    }, function () {
+        assert.ok(false, 'should not be rejected');
+        // the reasoning here is that the cancel method should not be
+        // useful as a way for one recipient of a promise to send a
+        // message to another recipient of the same promise.
+        // information only flows from the resolver to the promise.
+    })
+    .timeout(500)
+    .fail(function (exception) {
+        assert.ok(true, 'should time out');
+        assert.ok(canceled, 'cancelback should be called');
+    })
+    .finally(done)
+    .end()
+};
+
+exports['test downstream promise'] = function (assert, done) {
+    var parent = fixture(function () {
+        assert.ok(false, 'should not be canceled');
+    })
+    var child = parent.then(function () {
+        assert.ok(true, 'child should be fulfilled');
+    }, function () {
+        assert.ok(false, 'child should not be rejected');
+    });
+
+    var grandChild = child.then(function () {
+        assert.ok(true, 'grandchild should be fulfilled');
+    }, function () {
+        assert.ok(false, 'grandchild should not be rejected');
+    });
+
+    grandChild.cancel();
+
+    grandChild
+    .timeout(1000)
+    .then(function () {
+        assert.ok(true, 'grandchild should be fulfilled (cancel ignored)');
+    }, function () {
+        assert.ok(false, 'grandchild should not time out');
+    })
+    .finally(done)
+    .end()
+};
+
+if (module === require.main) {
+    require('test').run(exports);
+}
+


### PR DESCRIPTION
Added `promise.cancel()`, `Q.defer(canceler)` argument and
`promise.cancelable(canceler)` interface for making it possible to
support per-promise unregistration of interest in a promise resolution.
Cancelation is ignored by default.  Cancelation does not reject the
promise.  A cancelable promise should be constructed for each
independent receiver of a promise to guarantee that cancelation is not
observable and will not interfere with other receivers of a promise.

WARNING: Because cancelation must be handled with care in
security-concious situations, this feature may be removed for the good
of us all in a future major version.  Be excellent to each other.
