### PR TITLE
Adding basic long stack traces in V8 when `end`ing.

### DIFF
--- a/q.js
+++ b/q.js
@@ -355,9 +355,25 @@ function getStackFrames(objWithStack) {
     return stack;
 }
 
-var qFileName = typeof __filename !== "undefined" ? __filename :
-                Error.captureStackTrace ? new Error().stack.split("\n")[1]
-                    .match(/^    at ((?:\w+:\/\/)?[^:]+)/)[1] : null;
+var qFileName = typeof __filename !== "undefined" ? __filename : (function () {
+    if (!Error.captureStackTrace) {
+        return null;
+    }
+
+    var oldPrepareStackTrace = Error.prepareStackTrace;
+
+    var theFileName;
+    Error.prepareStackTrace = function (error, frames) {
+        theFileName = frames[0].getFileName();
+    };
+
+    var dummy = {};
+    Error.captureStackTrace(dummy);
+    dummy.stack;
+    Error.prepareStackTrace = oldPrepareStackTrace;
+
+    return theFileName;
+}());
 
 /**
  * Performs a task in a future turn of the event loop.


### PR DESCRIPTION
This needs review in a few ways, but just might be good enough to merge as a starting point. Notably there should be very little performance impact since `Error.captureStackTrace` gives us a lazily-evaluated getter and we defer parsing/filtering/assembling until `.end()` is called.

Points of concern:
- Copied a bunch of Google code from <a href="https://github.com/tlrobinson/long-stack-traces">tlrobinson/long-stack-traces</a>. Not sure how we want to handle that, e.g. where the copyright notice/disclaimer goes, whether I should have left the style as-is or integrated it as I did, how to handle the insertion I made (`<inserted by @domenic>`), etc. Please advise.
- Promises are now carrying around a `promise.stack` getter. This might have security implications. It seemed like the only way to do this, without a weak map/private names. And it's rather convenient.

Going forward:
- We should record some or all messages sent to a promise, most importantly `then`s. See discussion in #57 for an example scenario where more stuff could be caught. This is quite possible; I managed to log some of the stack frames we'd want to the console. The only tricky part is carrying them around until they're desired, especially while preserving the performant laziness advantage.
- We should update rejection reason stacks (when the rejection reasons are error instances, as they should be) to be in this format as well.
