### PR TITLE
Fix unhandled exception when rejection reason is not an Exception

### DIFF
--- a/q.js
+++ b/q.js
@@ -1293,7 +1293,7 @@ function end(promise) {
             // the stack trace of the promise we are ``end``ing. See #57.
             if (Error.captureStackTrace) {
                 var errorStackFrames = getStackFrames(error);
-	        if (errorStackFrames){
+                if (errorStackFrames){
                     var promiseStackFrames = getStackFrames(promise);
 
                     var combinedStackFrames = errorStackFrames.concat(
@@ -1301,7 +1301,7 @@ function end(promise) {
                       promiseStackFrames
                     );
                   error.stack = formatStackTrace(error, combinedStackFrames);
-		}
+                }
             }
 
             throw error;


### PR DESCRIPTION
The backtrace rewriting in `Q.end` assumes that the `error` argument is
always an Exception. But that's not the case, and it looks like the
API docs agree that it's "usually" an Exception, but can be any object
representing the reason for rejection.

It's easily demonstrated with a jQuery.ajax request. The following
causes an unhandled exception in Q, under Chrome:

```
Q.when($.ajax({url: '/nonexistent_path'})).end()
```

The promise gets rejected and the rejection reason is a jqXHR object,
which is not an Exception.  So `getStackFrames(error)` returns
undefined, and Q tries to call `concat` on undefined.

This patch just gives up on trying to rewrite the stack if we're
unable to retrieve stack frames.
