### PR TITLE
Prevent memory leaks in Q.timeout

### DIFF
--- a/q.js
+++ b/q.js
@@ -1334,10 +1334,14 @@ function end(promise) {
 exports.timeout = timeout;
 function timeout(promise, ms) {
     var deferred = defer();
-    when(promise, deferred.resolve, deferred.reject);
-    setTimeout(function () {
+    var timeoutId = setTimeout(function () {
         deferred.reject(new Error("Timed out after " + ms + "ms"));
     }, ms);
+
+    when(promise, function(object) {
+        clearTimeout(timeoutId);
+        deferred.resolve(object);
+    }, deferred.reject);
     return deferred.promise;
 }
 


### PR DESCRIPTION
If deferred resolved before timeout, timeoutId should be cleared by clearTimeout, otherwise garbage collector no frees the memory and heap size grows constantly.
