### PR TITLE
Test coverage for when and rejection

### DIFF
--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -1,6 +1,6 @@
 var Q = this.Q;
 if (typeof Q === "undefined" && typeof require !== "undefined") {
-    // For Node compatability.
+    // For Node compatibility.
     Q = require("../q");
 }
 
@@ -17,6 +17,21 @@ describe("defer and when", function () {
         turn++;
         return promise;
     });
+    
+    it("reject before when", function () {
+        var turn = 0;
+        var deferred = Q.defer();
+        deferred.reject(-1);
+        var promise = Q.when(deferred.promise, function() {
+	        	expect(true).toBe(false);	//couldn't find a prettier `fail()`
+    	    }, function (value) {
+        	    expect(turn).toEqual(1);
+            	expect(value).toEqual(-1);
+        	}
+        );
+        turn++;
+        return promise;
+    });
 
     it("when before resolve", function () {
         var turn = 0;
@@ -29,6 +44,26 @@ describe("defer and when", function () {
         Q.nextTick(function () {
             expect(turn).toEqual(1);
             deferred.resolve(10);
+            turn++;
+        });
+        turn++;
+        return promise;
+    });
+    
+    it("when before reject", function () {
+        var turn = 0;
+        var deferred = Q.defer();
+        var promise = deferred.promise.then(function() {
+	        	expect(true).toBe(false);	//couldn't find a prettier `fail()`
+	        }, function (value) {
+	            expect(turn).toEqual(2);
+	            expect(value).toEqual(-1);
+	            turn++;
+	        }
+	    );
+        Q.nextTick(function () {
+            expect(turn).toEqual(1);
+            deferred.reject(-1);
             turn++;
         });
         turn++;


### PR DESCRIPTION
Hi there,

I had an error in my code, wanted to make sure Q wasn't the source of it, so I added this test case… Q was perfectly fine, but that's still a small increase in coverage, so you might be interested in it.

It simply mimicks the `when` / `resolve` tests couple with `reject`.

Best regards,
Matti
