### PR TITLE
Return object rather than set value in promise.put

### DIFF
--- a/q.js
+++ b/q.js
@@ -744,7 +744,8 @@ function resolve(object) {
             return object[name];
         },
         "put": function (name, value) {
-            return object[name] = value;
+            object[name] = value;
+            return object;
         },
         "del": function (name) {
             return delete object[name];


### PR DESCRIPTION
We probably want to return the object not the value set for the case of `put(key, value)` so that we can continue working with that value down the chain. Otherwise put usually becomes a dead end. To get the old behavior you'd simply do this:

``` javascript
Q.resolve({}).put('ans', 42).get('ans');
```
