### PR TITLE
Unhandled exception when rejection reason is RangeError

### DIFF
--- a/q.js
+++ b/q.js
@@ -1308,7 +1308,7 @@ function end(promise) {
             // trace by removing Node and Q cruft, then concatenating with
             // the stack trace of the promise we are ``end``ing. See #57.
             if (Error.captureStackTrace && typeof error === "object" &&
-                "stack" in error) {
+                error.stack) {
                 var errorStackFrames = getStackFrames(error);
                 var promiseStackFrames = getStackFrames(promise);
 


### PR DESCRIPTION
RangeErrors have a "stack" property, but it is undefined. You can demonstrate the problem like this:

``` javascript
var stackBuster = function(){ stackBuster() };
try {
  stackBuster()
} catch (err){
  Q.reject(err).end()
}
```

I'm not quite sure how to make a unit test for this, because both the good case and the bad case result in generic "Script Error" messages on the global error handler.
