### PR TITLE
Fix bug introduced by #90

### DIFF
--- a/q.js
+++ b/q.js
@@ -1307,9 +1307,9 @@ function end(promise) {
             // If possible (that is, if in V8), transform the error stack
             // trace by removing Node and Q cruft, then concatenating with
             // the stack trace of the promise we are ``end``ing. See #57.
+            var errorStackFrames;
             if (Error.captureStackTrace && typeof error === "object" &&
-                error.stack) {
-                var errorStackFrames = getStackFrames(error);
+                (errorStackFrames = getStackFrames(error)) ) {
                 var promiseStackFrames = getStackFrames(promise);
 
                 var combinedStackFrames = errorStackFrames.concat(


### PR DESCRIPTION
Sorry, my patch for #90 introduced a problem. `error.stack` gets rendered and cached the first time someone accesses it, so if we access it before invoking `getStackFrames`, the custom `prepareStackTrace` never gets called.

This patch makes it so we only ever access `stack` via `getStackFrames`. 
