### PR TITLE
Make stack trace filtering work when concatenating assets

### DIFF
--- a/q.js
+++ b/q.js
@@ -94,6 +94,10 @@
 })(function (require, exports) {
 "use strict";
 
+
+// All code after this point will be filtered from stack traces.
+captureLine(new Error);
+
 // shims
 
 // used for fallback "defend" and in "allResolved"
@@ -349,6 +353,14 @@ function formatSourcePosition(frame) {
     return line;
 }
 
+function isInternalFrame(fileName, frame) {
+    if (fileName !== qFileName){
+        return false;
+    }
+    var line = frame.getLineNumber();
+    return line >= qStartingLine && line <= qEndingLine;
+}
+
 /*
  * Retrieves an array of structured stack frames parsed from the ``stack``
  * property of a given object.
@@ -369,7 +381,7 @@ function getStackFrames(objectWithStack) {
             return (
                 fileName !== "module.js" &&
                 fileName !== "node.js" &&
-                fileName !== qFileName
+                !isInternalFrame(fileName, frame)
             );
         });
     };
@@ -381,27 +393,33 @@ function getStackFrames(objectWithStack) {
     return stack;
 }
 
-// discover own file name for filtering stack traces
-var qFileName;
-if (Error.captureStackTrace) {
-    qFileName = (function () {
-        var fileName;
+// discover own file name and line number range for filtering stack
+// traces
+var qFileName, qStartingLine, qEndingLine;
+function captureLine(objectWithStack) {
+    if (Error.captureStackTrace) {
+        var fileName, lineNumber;
 
         var oldPrepareStackTrace = Error.prepareStackTrace;
 
         Error.prepareStackTrace = function (error, frames) {
             fileName = frames[0].getFileName();
+            lineNumber = frames[0].getLineNumber();
         };
 
         // teases call of temporary prepareStackTrace
         // JSHint and Closure Compiler generate known warnings here
         /*jshint expr: true */
-        new Error().stack;
+        objectWithStack.stack;
 
         Error.prepareStackTrace = oldPrepareStackTrace;
-
-        return fileName;
-    })();
+        qFileName = fileName;
+        if (qStartingLine){
+            qEndingLine = lineNumber;
+        } else {
+            qStartingLine = lineNumber;
+        }
+    }
 }
 
 function deprecate(fn, name, alternative){
@@ -1469,5 +1487,9 @@ function ninvoke(object, name /*, ...args*/) {
 }
 
 defend(exports);
+
+
+captureLine(new Error);
+// All code before this point will be filtered from stack traces.
 
 });


### PR DESCRIPTION
If Q is concatenated together with the rest of your Javascript and
served to the browser in a single file, it will filter stack traces
too aggressively, because it considers everything in the same file as
internal.

This change causes it to detect the start and end line numbers for its
own implementation so it can filter correctly even if there's other
code delivered in the same file.
