### PR TITLE
Add optional global error trap

### DIFF
--- a/q.js
+++ b/q.js
@@ -1299,6 +1299,12 @@ function fin(promise, callback) {
     });
 }
 
+var globalErrorTrap = null;
+exports.onError = onError;
+function onError(handler){
+  globalErrorTrap = handler;
+}
+
 /**
  * Terminates a chain of promises, forcing rejections to be
  * thrown as exceptions.
@@ -1326,7 +1332,11 @@ function end(promise) {
                 error.stack = formatStackTrace(error, combinedStackFrames);
             }
 
+	  if (globalErrorTrap){
+	    globalErrorTrap(error)
+	  } else {
             throw error;
+	  }
         });
     });
 }


### PR DESCRIPTION
Sometimes window.onerror is just not good enough. For example, under
Chrome you lose your stack trace.

This exposes a new function on Q that lets you set a global error
handler, which is called whenever Q.end() would have otherwise generated an
unhandled exception. Example usage:

``` javascript
Q.onError(function(err){
  // Post your error to the server...
});
```

Note that if you still want the unhandled exception too (which is helpful in the console), you can just make your onError handle rethrow.
