### PR TITLE
Speed up Q.all when not all values are promises

### DIFF
--- a/q.js
+++ b/q.js
@@ -1227,13 +1227,20 @@ function all(promises) {
         }
         var deferred = defer();
         array_reduce(promises, function (undefined, promise, index) {
-            when(promise, function (value) {
-                promises[index] = value;
+            if (isFulfilled(promise)) {
+                promises[index] = valueOf(promise);
                 if (--countDown === 0) {
                     deferred.resolve(promises);
                 }
-            })
-            .fail(deferred.reject);
+            } else {
+                when(promise, function (value) {
+                    promises[index] = value;
+                    if (--countDown === 0) {
+                        deferred.resolve(promises);
+                    }
+                })
+                .fail(deferred.reject);
+            }
         }, void 0);
         return deferred.promise;
     });


### PR DESCRIPTION
In the case where either:

 a) Not all values in the input array are promises (many orders of magnitude improvement)
 b) Some of the promises are already resolve (about twice as quick).

It does this by not waiting till the next turn of the event loop when it is un-necessary to do so.

Deferred will already ensure that the overall behaviour of all is correct with regard to resolving exactly once.

I've also tested this when all values are promises and the overhead is tiny (for Q.all on 10,000 promises it takes about `1500ms` with the old `Q.all` and `1550ms` with the new `Q.all`

For an equivalent number of resolved promises the old method gave `1500ms` while the new method gave `500ms`.

**For an equivalent number of plain strings (not from promises) the old method gave `1250ms` and the new method gave `16ms`.**

It also works great with mixtures of the three categories.
