### PR TITLE
Add progress notification support. Closes #63.

### DIFF
--- a/q.js
+++ b/q.js
@@ -457,15 +457,18 @@ function defer() {
     // forward to the resolved promise.  We coerce the resolution value to a
     // promise using the ref promise because it handles both fully
     // resolved values and other promises gracefully.
-    var pending = [], value;
+    var pending = [], progressListeners = [], value;
 
     var deferred = object_create(defer.prototype);
     var promise = object_create(makePromise.prototype);
 
-    promise.promiseSend = function () {
+    promise.promiseSend = function (op, _, __, progress) {
         var args = array_slice(arguments);
         if (pending) {
             pending.push(args);
+            if (op === "when" && progress) {
+                progressListeners.push(progress);
+            }
         } else {
             nextTick(function () {
                 value.promiseSend.apply(value, args);
@@ -495,6 +498,7 @@ function defer() {
             });
         }, void 0);
         pending = void 0;
+        progressListeners = void 0;
         return value;
     }
 
@@ -504,6 +508,17 @@ function defer() {
     deferred.resolve = become;
     deferred.reject = function (exception) {
         return become(reject(exception));
+    };
+    deferred.notify = function () {
+        if (pending) {
+            var args = arguments;
+
+            array_reduce(progressListeners, function (undefined, progressListener) {
+                nextTick(function () {
+                    progressListener.apply(void 0, args);
+                });
+            }, void 0);
+        }
     };
 
     return deferred;
@@ -580,7 +595,9 @@ function makePromise(descriptor, fallback, valueOf, exception) {
         } catch (exception) {
             result = reject(exception);
         }
-        resolved(result);
+        if (resolved) {
+            resolved(result);
+        }
     };
 
     if (valueOf) {
@@ -597,8 +614,8 @@ function makePromise(descriptor, fallback, valueOf, exception) {
 }
 
 // provide thenables, CommonJS/Promises/A
-makePromise.prototype.then = function (fulfilled, rejected) {
-    return when(this, fulfilled, rejected);
+makePromise.prototype.then = function (fulfilled, rejected, progressed) {
+    return when(this, fulfilled, rejected, progressed);
 };
 
 // Chainable methods
@@ -614,7 +631,7 @@ array_reduce(
         "all", "allResolved",
         "view", "viewInfo",
         "timeout", "delay",
-        "catch", "finally", "fail", "fin", "end"
+        "catch", "finally", "fail", "fin", "progress", "end"
     ],
     function (prev, name) {
         makePromise.prototype[name] = function () {
@@ -750,9 +767,9 @@ function resolve(object) {
     }
     // assimilate thenables, CommonJS/Promises/A
     if (object && typeof object.then === "function") {
-        var result = defer();
-        object.then(result.resolve, result.reject);
-        return result.promise;
+        var deferred = defer();
+        object.then(deferred.resolve, deferred.reject, deferred.notify);
+        return deferred.promise;
     }
     return makePromise({
         "when": function (rejected) {
@@ -876,13 +893,14 @@ function view(object) {
  *    called, but not both.
  * 3. that fulfilled and rejected will not be called in this turn.
  *
- * @param value     promise or immediate reference to observe
- * @param fulfilled function to be called with the fulfilled value
- * @param rejected  function to be called with the rejection exception
+ * @param value      promise or immediate reference to observe
+ * @param fulfilled  function to be called with the fulfilled value
+ * @param rejected   function to be called with the rejection exception
+ * @param progressed function to be called on any progress notifications
  * @return promise for the return value from the invoked callback
  */
 exports.when = when;
-function when(value, fulfilled, rejected) {
+function when(value, fulfilled, rejected, progressed) {
     var deferred = defer();
     var done = false;   // ensure the untrusted promise makes at most a
                         // single call to one of the callbacks
@@ -903,8 +921,9 @@ function when(value, fulfilled, rejected) {
         }
     }
 
+    var resolvedValue = resolve(value);
     nextTick(function () {
-        resolve(value).promiseSend("when", function (value) {
+        resolvedValue.promiseSend("when", function (value) {
             if (done) {
                 return;
             }
@@ -920,6 +939,11 @@ function when(value, fulfilled, rejected) {
             deferred.resolve(_rejected(exception));
         });
     });
+
+    // Progress listeners need to be attached in the current tick.
+    if (progressed) {
+        resolvedValue.promiseSend("when", void 0, void 0, progressed);
+    }
 
     return deferred.promise;
 }
@@ -1314,6 +1338,20 @@ exports["catch"] = // XXX experimental
 exports.fail = fail;
 function fail(promise, rejected) {
     return when(promise, void 0, rejected);
+}
+
+/**
+ * Attaches a listener that can respond to progress notifications from a
+ * promise's originating deferred. This listener receives the exact arguments
+ * passed to ``deferred.notify``.
+ * @param {Any*} promise for something
+ * @param {Function} callback to receive any progress notifications
+ * @returns the given promise, unchanged
+ */
+exports.progress = progress;
+function progress(promise, progressed) {
+    when(promise, void 0, void 0, progressed);
+    return promise;
 }
 
 /**

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -139,6 +139,311 @@ describe("always next tick", function () {
 
 });
 
+describe("progress", function () {
+
+    it("calls a single progress listener", function () {
+        var progressed = false;
+        var deferred = Q.defer();
+
+        var promise = Q.when(
+            deferred.promise,
+            function () {
+                expect(progressed).toBe(true);
+            },
+            function () {
+                expect(true).toBe(false);
+            },
+            function () {
+                progressed = true;
+            }
+        );
+
+        deferred.notify();
+        deferred.resolve();
+
+        return promise;
+    });
+
+    it("calls multiple progress listeners", function () {
+        var progressed1 = false;
+        var progressed2 = false;
+        var deferred = Q.defer();
+        var promise = Q.when(
+            deferred.promise,
+            function () {
+                expect(progressed1).toBe(true);
+                expect(progressed2).toBe(true);
+            },
+            function () {
+                expect(true).toBe(false);
+            },
+            function () {
+                progressed1 = true;
+            }
+        );
+        Q.when(deferred.promise, null, null, function () {
+            progressed2 = true;
+        });
+
+        deferred.notify();
+        deferred.resolve();
+
+        return promise;
+    });
+
+    it("calls all progress listeners even if one throws", function () {
+        var progressed1 = false;
+        var progressed2 = false;
+        var progressed3 = false;
+        var deferred = Q.defer();
+        var promise = Q.when(
+            deferred.promise,
+            function () {
+                expect(progressed1).toBe(true);
+                expect(progressed2).toBe(true);
+                expect(progressed3).toBe(true);
+            },
+            function () {
+                expect(true).toBe(false);
+            },
+            function () {
+                progressed1 = true;
+            }
+        );
+        Q.when(deferred.promise, null, null, function () {
+            progressed2 = true;
+            throw new Error("just a test, ok if it shows up in the console");
+        });
+        Q.when(deferred.promise, null, null, function () {
+            progressed3 = true;
+        });
+
+        deferred.notify();
+        deferred.resolve();
+
+        // In Node, swallow the eventually-thrown error.
+        function uncaughtExceptionHandler() { }
+        if (typeof process === "object") {
+            process.on("uncaughtException", uncaughtExceptionHandler);
+            promise.fin(function () {
+                process.removeListener("uncaughtException", uncaughtExceptionHandler);
+            })
+        }
+
+        return promise;
+    });
+
+    it("calls the progress listener even if later rejected", function () {
+        var progressed = false;
+        var deferred = Q.defer();
+        var promise = Q.when(
+            deferred.promise,
+            function () {
+                expect(true).toBe(false);
+            },
+            function () {
+                expect(progressed).toEqual(true);
+            },
+            function () {
+                progressed = true;
+            }
+        );
+
+        deferred.notify();
+        deferred.reject();
+
+        return promise;
+    });
+
+    it("calls the progress listener with the notify values", function () {
+        var progressValues = [];
+        var desiredProgressValues = [{}, {}, "foo", 5];
+        var deferred = Q.defer();
+        var promise = Q.when(
+            deferred.promise,
+            function () {
+                for (var i = 0; i < desiredProgressValues.length; ++i) {
+                    var desired = desiredProgressValues[i];
+                    var actual = progressValues[i];
+                    expect(actual).toBe(desired);
+                }
+            },
+            function () {
+                expect(true).toBe(false);
+            },
+            function (value) {
+                progressValues.push(value);
+            }
+        );
+
+        for (var i = 0; i < desiredProgressValues.length; ++i) {
+            deferred.notify(desiredProgressValues[i]);
+        }
+        deferred.resolve();
+
+        return promise;
+    });
+
+    it("does not call the progress listener if notify is called after fulfillment", function () {
+        var deferred = Q.defer();
+        var called = false;
+
+        Q.when(deferred.promise, null, null, function () {
+            called = true;
+        });
+
+        deferred.resolve();
+        deferred.notify();
+
+        return Q.delay(10).then(function () {
+            expect(called).toBe(false);
+        });
+    });
+
+    it("does not call the progress listener if notify is called after rejection", function () {
+        var deferred = Q.defer();
+        var called = false;
+
+        Q.when(deferred.promise, null, null, function () {
+            called = true;
+        });
+
+        deferred.reject();
+        deferred.notify();
+
+        return Q.delay(10).then(function () {
+            expect(called).toBe(false);
+        });
+    });
+
+    it("should not save and re-emit progress notifications", function () {
+        var deferred = Q.defer();
+        var progressValues = [];
+
+        deferred.notify(1);
+
+        var promise = Q.when(
+            deferred.promise,
+            function () {
+                expect(progressValues).toEqual([2]);
+            },
+            function () {
+                expect(true).toBe(false);
+            },
+            function (progressValue) {
+                progressValues.push(progressValue);
+            }
+        );
+
+        deferred.notify(2);
+        deferred.resolve();
+
+        return promise;
+    });
+
+    it("should allow attaching progress listeners w/ .progress", function () {
+        var progressed = false;
+        var deferred = Q.defer();
+
+        deferred.promise.progress(function () {
+            progressed = true;
+        });
+
+        deferred.notify();
+        deferred.resolve();
+
+        return deferred.promise;
+    });
+
+    it("should allow attaching progress listeners w/ Q.progress", function () {
+        var progressed = false;
+        var deferred = Q.defer();
+
+        Q.progress(deferred.promise, function () {
+            progressed = true;
+        });
+
+        deferred.notify();
+        deferred.resolve();
+
+        return deferred.promise;
+    });
+
+    it("should call the progress listener with undefined context", function () {
+        var progressed = false;
+        var progressContext = {};
+        var deferred = Q.defer();
+        var promise = Q.when(
+            deferred.promise,
+            function () {
+                expect(progressed).toBe(true);
+                expect(progressContext).toBe(undefined);
+            },
+            function () {
+                expect(true).toBe(false);
+            },
+            function () {
+                progressed = true;
+                progressContext = this;
+            }
+        );
+
+        deferred.notify();
+        deferred.resolve();
+
+        return promise;
+    });
+
+    it("should forward all notify arguments to listeners", function () {
+        var progressValueArrays = [];
+        var deferred = Q.defer();
+
+        var promise = Q.when(
+            deferred.promise,
+            function () {
+                expect(progressValueArrays).toEqual([[1], [2, 3], [4, 5, 6]]);
+            },
+            function () {
+                expect(true).toBe(false);
+            },
+            function () {
+                var args = Array.prototype.slice.call(arguments);
+                progressValueArrays.push(args);
+            }
+        );
+
+        deferred.notify(1);
+        deferred.notify(2, 3);
+        deferred.notify(4, 5, 6);
+        deferred.resolve();
+
+        return promise;
+    });
+
+    it("should work with .then as well", function () {
+        var progressed = false;
+        var deferred = Q.defer();
+
+        var promise = deferred.promise.then(
+            function () {
+                expect(progressed).toBe(true);
+            },
+            function () {
+                expect(true).toBe(false);
+            },
+            function () {
+                progressed = true;
+            }
+        );
+
+        deferred.notify();
+        deferred.resolve();
+
+        return promise;
+    });
+
+});
+
 describe("promises for objects", function () {
 
     describe("get", function () {
@@ -876,6 +1181,25 @@ describe("thenables", function () {
         })
         .then(function (undefined) {
             expect(undefined).toEqual(void 0);
+        });
+    });
+
+    it("assimilates a thenable with progress and fulfillment", function () {
+        var progressValueArrays = [];
+        return Q.resolve({
+            then: function (fulfilled, rejected, progressed) {
+                Q.nextTick(function () {
+                    progressed(1, 2);
+                    progressed(3, 4, 5);
+                    fulfilled();
+                });
+            }
+        })
+        .progress(function () {
+            progressValueArrays.push(Array.prototype.slice.call(arguments));
+        })
+        .then(function () {
+            expect(progressValueArrays).toEqual([[1, 2], [3, 4, 5]]);
         });
     });
 


### PR DESCRIPTION
New API:
- `deferred.notify(...args)`
- `promise.then(f, r, p)`: `p` will get `...args`
- `promise.progress(p)` is a shortcut for `promise.then(null, null, p)`.
- `Q.progress(promise, p)` is equivalent to `promise.progress(p)`.
