### PR TITLE
Simplify nend

### DIFF
--- a/q.js
+++ b/q.js
@@ -1578,19 +1578,15 @@ function ninvoke(object, name /*, ...args*/) {
 exports.nend = nend;
 function nend(promise, nodeback) {
     if (nodeback) {
-        var deferred = defer();
         promise.then(function (value) {
             nextTick(function () {
-                deferred.resolve();
                 nodeback(null, value);
             });
         }, function (error) {
             nextTick(function () {
-                deferred.resolve();
                 nodeback(error);
             });
         });
-        return deferred.promise;
     } else {
         return promise;
     }

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -1415,16 +1415,22 @@ describe("node support", function () {
 
         it("calls back with a resolution", function () {
             var spy = jasmine.createSpy();
-            return Q.resolve(10).nend(spy)
-            .then(function () {
+            Q.resolve(10).nend(spy);
+            waitsFor(function () {
+                return spy.argsForCall.length;
+            });
+            runs(function () {
                 expect(spy.argsForCall).toEqual([[null, 10]]);
             });
         });
 
         it("calls back with an error", function () {
             var spy = jasmine.createSpy();
-            return Q.reject(10).nend(spy)
-            .then(function () {
+            Q.reject(10).nend(spy);
+            waitsFor(function () {
+                return spy.argsForCall.length;
+            });
+            runs(function () {
                 expect(spy.argsForCall).toEqual([[10]]);
             });
         });


### PR DESCRIPTION
Do not return a promise if a callback is given.

Spec no longer depends on returned promise.
