### PR TITLE
Introduce `Q.onerror` for a global rejection trap.

### DIFF
--- a/q.js
+++ b/q.js
@@ -1433,7 +1433,11 @@ function end(promise) {
                 error.stack = formatStackTrace(error, combinedStackFrames);
             }
 
-            throw error;
+            if (exports.onerror) {
+                exports.onerror(error);
+            } else {
+                throw error;
+            }
         });
     });
 }
@@ -1591,8 +1595,6 @@ function nend(promise, nodeback) {
         return promise;
     }
 }
-
-defend(exports);
 
 // All code before this point will be filtered from stack traces.
 var qEndingLine = captureLine();


### PR DESCRIPTION
- Fixes #94.
- Tests switched to use this instead of the previous glob of code for doing similar things.
- Exports are now undefended (i.e. not frozen).
