### PR TITLE
Fixing the [sometimes] broken link to 'Q API Reference'

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,7 +616,7 @@ will [be ameliorated][streamsnext].
 
 A method-by-method [Q API reference][reference] is available on the wiki.
 
-[reference]: q/wiki/API-Reference
+[reference]: https://github.com/kriskowal/q/wiki/API-Reference
 
 ## More Examples
 


### PR DESCRIPTION
giving the 'Q API Reference' link in the README.md an absolute path, so it works from the Github project page, and documentup page.
