### PR TITLE
Clear timeout if original promise rejected in Q.timeout

### DIFF
--- a/q.js
+++ b/q.js
@@ -1346,7 +1346,11 @@ function timeout(promise, ms) {
     when(promise, function (value) {
         clearTimeout(timeoutId);
         deferred.resolve(value);
-    }, deferred.reject);
+    }, function (exception) {
+        clearTimeout(timeoutId);
+        deferred.reject(exception);
+    });
+
     return deferred.promise;
 }
 


### PR DESCRIPTION
If original promise in Q.timeout rejected before setTimeout occured, timer should be cleared.
