### PR TITLE
Add timeout to returned promise in jasmine-promise

### DIFF
--- a/spec/lib/jasmine-promise.js
+++ b/spec/lib/jasmine-promise.js
@@ -66,7 +66,7 @@ describe('jasmine-promise', function() {
     }
   });
   // These are expected to fail. Remove the x from xdescribe to test that.
-  describe('failure cases (expected to fail)', function() {
+  xdescribe('failure cases (expected to fail)', function() {
     it('fails if the deferred is rejected', function() {
       var deferred = Q.defer();
       deferred.reject();


### PR DESCRIPTION
Also call onComplete() if an error is raised, as otherwise my runner never terminated and gave no indication.
