### PR TITLE
Remove reference to deleted `end` function.

### DIFF
--- a/q.js
+++ b/q.js
@@ -529,7 +529,7 @@ array_reduce(
         "fapply", "fcall", "fbind",
         "all", "allResolved",
         "timeout", "delay",
-        "catch", "finally", "fail", "fin", "progress", "end", "done",
+        "catch", "finally", "fail", "fin", "progress", "done",
         "nfcall", "nfapply", "nfbind",
         "ncall", "napply", "nbind",
         "npost", "nsend",


### PR DESCRIPTION
End was still being copied onto the promise prototype even though it no longer exists.

There were also a few references left to `end` in the wiki, I changed them to `done`.
