### PR TITLE
Add support for Vert.x runtime with use of runOnLoop

### DIFF
--- a/q.js
+++ b/q.js
@@ -109,10 +109,23 @@ if (typeof process !== "undefined") {
         channel.port2.postMessage(0);
     };
 } else {
-    // old browsers
-    nextTick = function (task) {
-        setTimeout(task, 0);
-    };
+    var vertx = null;
+
+    try {
+        vertx = require('vertx.js');
+    } catch (exception) {
+        // no require or no vertx
+        vertx = null;
+    }
+
+    if (vertx) {
+        nextTick = vertx.runOnLoop;
+    } else {
+        // old browsers
+        nextTick = function (task) {
+            setTimeout(task, 0);
+        };
+    }
 }
 
 // Attempt to make generics safe in the face of downstream


### PR DESCRIPTION
Vert.x's JavaScript support is built on Rhino, and Rhino doesn't
support setTimeout.  This change tests for the Vert.x environment and
uses uses the runOnLoop function for Q's nextTick.
