### PR TITLE
Support component and bower

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,0 +1,9 @@
+{
+    "name": "q",
+    "version": "0.8.12",
+    "description": "A library for promises (CommonJS/Promises/A,B,D)",
+    "scripts": ["q.js"],
+    "main": "q.js",
+    "dependencies": {},
+    "license": "MIT"
+}


### PR DESCRIPTION
Add component.json.  This is needed to support [component](https://github.com/component/component) and [bower](http://twitter.github.com/bower/).  Some of the things that I added relative to #161 are needed to support component, but I also added description and license as these are used by the search functionality and don't add much maintenance overhead.
