### PR TITLE
Remove `uncurryThis` via Function.bind.bind(Function.call).

### DIFF
--- a/q.js
+++ b/q.js
@@ -119,7 +119,7 @@ if (typeof process !== "undefined") {
 var uncurryThis = function (f) {
     var call = Function.call;
     return function () {
-        return f.call.apply(f, arguments);
+        return call.apply(f, arguments);
     };
 };
 


### PR DESCRIPTION
Not sure in which theory the `Function.bind.bind(Function.call)` variation should be faster. `Function.bind` is native but does much more then what you really need here.
I tested it extensively a few weeks ago with prefjs.com, and it is 2-5 times slower on Firefox and Chrome.

EDIT: I have to correct myself. It is not slower (only) because of `Function.bind`, but (also) because it is done twice.
