### PR TITLE
Fix spec in case strict mode is not supported.

### DIFF
--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -11,6 +11,13 @@ if (typeof Q === "undefined" && typeof require !== "undefined") {
 
 var REASON = "this is not an error, but it might show up in the console";
 
+var global = this;
+
+var STRICT_MODE_CAPABLE = (function(){
+    "use strict";
+    return !this;
+})();
+
 afterEach(function () {
     Q.onerror = null;
 });
@@ -406,7 +413,7 @@ describe("progress", function () {
             deferred.promise,
             function () {
                 expect(progressed).toBe(true);
-                expect(progressContext).toBe(undefined);
+                expect(progressContext).toBe(STRICT_MODE_CAPABLE ? undefined : global);
             },
             function () {
                 expect(true).toBe(false);
@@ -2080,4 +2087,3 @@ describe("possible regressions", function () {
     });
 
 });
-


### PR DESCRIPTION
In browsers that does not support `"use strict"` (including IE<=9), spec will fail.
