### PR TITLE
Add a test for promise.all() - also make it work

### DIFF
--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -1054,6 +1054,14 @@ describe("all", function () {
         });
     });
 
+    it("resolves when called on a promise", function () {
+        return Q(10)
+        .all([Q(1), Q(2)])
+        .then(function (args) {
+            expect(args).toEqual([1, 2]);
+        });
+    });
+
 });
 
 describe("allResolved", function () {


### PR DESCRIPTION
This commit adds a small test case for `all()` as called on a promise. Not that this test case _fails_ at the moment, so that should also be fixed.

Additionally, I would expect this feature to be documented in the wiki. Currently it only gives an example of `Q.all()`, with the note that "[t]his method is often used in its static form".
