### PR TITLE
Lazy rethrow approach for simpler nextTick.

### DIFF
--- a/q.js
+++ b/q.js
@@ -90,40 +90,30 @@ if (typeof process !== "undefined") {
     (function () {
         // linked list of tasks (single, with head node)
         var head = {task: void 0, next: null}, tail = head,
-            maxPendingTicks = 2, pendingTicks = 0, queuedTasks = 0, usedTicks = 0,
-            requestTick;
+            running = false, requestTick;
 
         function onTick() {
-            // In case of multiple tasks ensure at least one subsequent tick
-            // to handle remaining tasks in case one throws.
-            --pendingTicks;
-
-            if (++usedTicks >= maxPendingTicks) {
-                // Amortize latency after thrown exceptions.
-                usedTicks = 0;
-                maxPendingTicks *= 4; // fast grow!
-                var expectedTicks = queuedTasks && Math.min(queuedTasks - 1, maxPendingTicks);
-                while (pendingTicks < expectedTicks) {
-                    ++pendingTicks;
-                    requestTick();
-                }
-            }
-
-            while (queuedTasks) {
-                --queuedTasks; // decrement here to ensure it's never negative
+            while (head.next) {
                 head = head.next;
                 var task = head.task;
                 head.task = void 0;
-                task();
+
+                try {
+                    task();
+                } catch (error) {
+                    setTimeout(function () {
+                        throw error;
+                    }, 0);
+                }
             }
 
-            usedTicks = 0;
+            running = false;
         }
 
         nextTick = function (task) {
             tail = tail.next = {task: task, next: null};
-            if (pendingTicks < ++queuedTasks && pendingTicks < maxPendingTicks) {
-                ++pendingTicks;
+            if (!running) {
+                running = true;
                 requestTick();
             }
         };


### PR DESCRIPTION
I'm still not 100% sure about this, but would give an simpler code, and better performances in case of thrown exceptions. The amortized algorithm gives an additional _O(t log n)_ or better (where _t_ = tick delay, _n_ = number of throws), while the "lazy re-throw" approach would give no additional delay on "good" tasks!

The downside is that re-throws are not in sync with other tasks. Also some environments could undesirably regenerate the error stack (?).
If those are not considered an issue, I could do some performance testing. 

Ideas?
