### PR TITLE
Q.timeout and progress

### DIFF
--- a/q.js
+++ b/q.js
@@ -1318,9 +1318,7 @@ function timeout(promise, ms) {
     }, function (exception) {
         clearTimeout(timeoutId);
         deferred.reject(exception);
-    }, function (progress) {
-        deferred.notify(progress);
-    });
+    }, deferred.notify);
 
     return deferred.promise;
 }


### PR DESCRIPTION
The promise created by the q.timeout method should react on progress calls. The current implementation swallows notifications of the wrapped promises so the event never reaches the actual .then observer.
