### PR TITLE
Add mention that .all()'s fulfilment values have ordered maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,10 +284,12 @@ return getUsername()
 });
 ```
 
-The ``all`` function returns a promise for an array of values.  If one
-of the given promise fails, the whole returned promise fails, not
-waiting for the rest of the batch.  If you want to wait for all of the
-promises to either be fulfilled or rejected, you can use
+The ``all`` function returns a promise for an array of values. When this 
+promise is fulfilled the order of its success values are maintained relative 
+to the original promises which the promise was dependant on.
+If one of the given promise fails, the whole returned promise fails, 
+not waiting for the rest of the batch.  If you want to wait for all of 
+the promises to either be fulfilled or rejected, you can use
 ``allResolved``.
 
 ```javascript


### PR DESCRIPTION
I was wondering if .all() maintained the order of the fulfilment values for each promise 
despite different promises resolving at different points in time.

I couldn't find this mentioned in the README so I wrote a personal test to find out 
and I've concluded that it's the case so I've mentioned it in the README.

``` javascript

// Testing if .all() maintains the order of the returned values

var q = require('q');

function soon (id, time) {
  var deffered = q.defer();
  setTimeout(function () {
    console.log(id + ' is done');
    deffered.resolve(id);
  }, time);
  return deffered.promise;
}

q.all([
  soon("a", 5000),
  soon("b", 100),
  soon("c", 2000)
])
.then(function (results) {
  console.log(results); // should be a, b, c and not b, c, a
});
```
