### PR TITLE
Cleanup of duplicate and no longer relevant chainable entries

### DIFF
--- a/q.js
+++ b/q.js
@@ -596,7 +596,6 @@ array_reduce(
         "timeout", "delay",
         "catch", "finally", "fail", "fin", "progress", "done",
         "nfcall", "nfapply", "nfbind", "denodeify", "nbind",
-        "ncall", "napply", "nbind",
         "npost", "nsend", "ninvoke",
         "nodeify"
     ],


### PR DESCRIPTION
ncall and napply were both removed months ago and nbind is listed twice.
