### PR TITLE
Make isPromise always return a boolean

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 <!-- vim:ts=4:sts=4:sw=4:et:tw=60 -->
 
+## 0.9.4
+ - `isPromise` and `isPromiseAlike` now always returns a boolean 
+   (even for falsy values)
+
 ## 0.9.3
 
  - Add the ability to give `Q.timeout`'s errors a custom error message. #270

--- a/q.js
+++ b/q.js
@@ -253,6 +253,11 @@ var object_keys = Object.keys || function (object) {
 
 var object_toString = uncurryThis(Object.prototype.toString);
 
+var is_object = function (object) {
+    //Implementation from https://github.com/documentcloud/underscore/
+    return object === Object(object);
+};
+
 // generator related shims
 
 function isStopIteration(exception) {
@@ -643,12 +648,12 @@ function valueOf(value) {
  */
 Q.isPromise = isPromise;
 function isPromise(object) {
-    return object && typeof object.promiseDispatch === "function";
+    return is_object(object) && typeof object.promiseDispatch === "function";
 }
 
 Q.isPromiseAlike = isPromiseAlike;
 function isPromiseAlike(object) {
-    return object && typeof object.then === "function";
+    return is_object(object) && typeof object.then === "function";
 }
 
 /**

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -2132,6 +2132,48 @@ describe("node support", function () {
 
 });
 
+describe("isPromise", function () {
+    it("returns true if passed a promise", function () {
+        expect(Q.isPromise(Q.resolve(10))).toBe(true);
+    });
+    
+    it("returns false if not passed a promise", function () {
+        expect(Q.isPromise(undefined)).toBe(false);
+        expect(Q.isPromise(null)).toBe(false);
+        expect(Q.isPromise(10)).toBe(false);
+        expect(Q.isPromise("str")).toBe(false);
+        expect(Q.isPromise("")).toBe(false);
+        expect(Q.isPromise(true)).toBe(false);
+        expect(Q.isPromise(false)).toBe(false);
+        expect(Q.isPromise({})).toBe(false);
+        expect(Q.isPromise({
+            then: function () {}
+        })).toBe(false);
+        expect(Q.isPromise(function () {})).toBe(false);
+    });
+});
+
+describe("isPromiseAlike", function () {
+    it("returns true if passed a promise like object", function () {
+        expect(Q.isPromiseAlike(Q.resolve(10))).toBe(true);
+        expect(Q.isPromiseAlike({
+            then: function () {}
+        })).toBe(true);
+    });
+    
+    it("returns false if not passed a promise like object", function () {
+        expect(Q.isPromiseAlike(undefined)).toBe(false);
+        expect(Q.isPromiseAlike(null)).toBe(false);
+        expect(Q.isPromiseAlike(10)).toBe(false);
+        expect(Q.isPromiseAlike("str")).toBe(false);
+        expect(Q.isPromiseAlike("")).toBe(false);
+        expect(Q.isPromiseAlike(true)).toBe(false);
+        expect(Q.isPromiseAlike(false)).toBe(false);
+        expect(Q.isPromiseAlike({})).toBe(false);
+        expect(Q.isPromiseAlike(function () {})).toBe(false);
+    });
+});
+
 if (typeof require === "function") {
     var domain;
     try {


### PR DESCRIPTION
isPromise returned the object to test when it was falsy, instead of
returning false.
For example isPromise(null) would return null.
For the sake of consistency isPromise now always returns a boolean.

Also updates isPromiseAlike and adds tests for both.

Tested in node 0.10.4, Chrome 26.0.1410.64, IE10 and Firefox 20.0.1
