### PR TITLE
Fixed bower link

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The Q module can be loaded as:
     the [q](https://npmjs.org/package/q) package
 -   An AMD module
 -   A [component](https://github.com/component/component) as ``microjs/q``
--   Using [bower](http://twitter.github.com/bower/) as ``microjs/q``
+-   Using [bower](http://bower.io/) as ``q``
 -   Using [NuGet](http://nuget.org/) as [Q](https://nuget.org/packages/q)
 
 Q can exchange promises with jQuery, Dojo, When.js, WinJS, and more.


### PR DESCRIPTION
Bower has moved to bower.io. Also, the package is called just `q` on bower.
