### PR TITLE
Introduce `promise.inspect` and `Q.allSettled`

### DIFF
--- a/q.js
+++ b/q.js
@@ -1337,7 +1337,7 @@ function all(promises) {
  * (or values)
  * @return a promise for an array of promises
  */
-Q.allResolved = allResolved;
+Q.allResolved = deprecate(allResolved, "allResolved", "allSettled");
 function allResolved(promises) {
     return when(promises, function (promises) {
         promises = array_map(promises, resolve);
@@ -1346,6 +1346,25 @@ function allResolved(promises) {
         })), function () {
             return promises;
         });
+    });
+}
+
+Q.allSettled = allSettled;
+function allSettled(values) {
+    return when(values, function (values) {
+        return all(array_map(values, function (value, i) {
+            return when(
+                value,
+                function (fulfillmentValue) {
+                    values[i] = { state: "fulfilled", value: fulfillmentValue };
+                    return values[i];
+                },
+                function (reason) {
+                    values[i] = { state: "rejected", reason: reason };
+                    return values[i];
+                }
+            );
+        })).thenResolve(values);
     });
 }
 


### PR DESCRIPTION
These replace `promise.valueOf` and `Q.allResolved`, respectively. See API proposals in #256 and #257.

The old methods are left as deprecated.

The last issue regards the fate of `Q.nearer`. I think I broke it, but IIRC we wanted to do it differently anyway (e.g. always return a promise). Thoughts?
