### PR TITLE
Use Function constructor instead of eval

### DIFF
--- a/q.js
+++ b/q.js
@@ -294,7 +294,7 @@ if (typeof ReturnValue !== "undefined") {
 // this block.
 var hasES6Generators;
 try {
-    eval("(function* (){ yield 1; })");
+    new Function("(function* (){ yield 1; })");
     hasES6Generators = true;
 } catch (e) {
     hasES6Generators = false;


### PR DESCRIPTION
`eval` can affect the variables in the scope and it makes performance worse.
Instead of it, using Function constructor is better.
