### PR TITLE
Add nice unhandled-rejection tracking API as per #265.

### DIFF
--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -2415,14 +2415,44 @@ describe("unhandled rejection reporting", function () {
         deferred.resolve();
         deferred.reject();
 
-        expect(Q.unhandledReasons.length).toEqual(0);
+        expect(Q.getUnhandledReasons().length).toEqual(0);
     });
 
     it("doesn't report when you chain off a rejection", function () {
         return Q.reject("this will be handled").get("property").fail(function () {
             // now it should be handled.
         }).fin(function() {
-            expect(Q.unhandledReasons.length).toEqual(0);
+            expect(Q.getUnhandledReasons().length).toEqual(0);
         });
+    });
+
+    it("reports the most basic case", function () {
+        Q.reject("a reason");
+
+        expect(Q.getUnhandledReasons()).toEqual(["a reason"]);
+    });
+
+    it("doesn't let you mutate the internal array", function () {
+        Q.reject("a reason");
+
+        Q.getUnhandledReasons().length = 0;
+        expect(Q.getUnhandledReasons()).toEqual(["a reason"]);
+    });
+
+    it("resets after calling `Q.resetUnhandledRejections`", function () {
+        Q.reject("a reason");
+
+        Q.resetUnhandledRejections();
+        expect(Q.getUnhandledReasons()).toEqual([]);
+    });
+
+    it("stops tracking after calling `Q.stopUnhandledRejectionTracking`", function () {
+        Q.reject("a reason");
+
+        Q.stopUnhandledRejectionTracking();
+
+        Q.reject("another reason");
+
+        expect(Q.getUnhandledReasons()).toEqual([]);
     });
 });


### PR DESCRIPTION
- Closes #244 and closes #245 since `Q.stopUnhandledRejectionTracking()` removes the `process.on("exit", ...)` handler.
- Closes #255 since `Q.stopUnhandledRejectionTracking()` prevents any storage or tracking of unhandled rejections or unhandled rejection reasons.
- Closes #265 via the new `Q.getUnhandledReasons()` and `Q.resetUnhandledRejections()` APIs, which are useful mainly for testing and diagnostics.
- Closes #278 by slightly reordering the code inside `trackRejection`.
