### PR TITLE
Add the `spawn` function for ES6 generators

### DIFF
--- a/examples/async-generators/3-spawn.js
+++ b/examples/async-generators/3-spawn.js
@@ -1,0 +1,27 @@
+var Q = require('../../q');
+
+function delay(millis, answer) {
+    const deferredResult = Q.defer();
+    setTimeout(function() {
+        deferredResult.resolve(answer);
+    }, millis);
+    return deferredResult.promise;
+}
+
+function foo() {
+    return delay(1000, 5);
+}
+
+function bar() {
+    return delay(1000, 10);
+}
+
+Q.spawn(function*() {
+    var x = yield foo();
+    console.log(x);
+
+    var y = yield bar();
+    console.log(y);
+
+    console.log('result', x + y);
+});

--- a/q.js
+++ b/q.js
@@ -1126,6 +1126,18 @@ function async(makeGenerator) {
     };
 }
 
+/**
+ * The spawn function is a small wrapper around async that immediately
+ * calls the generator and also ends the promise chain, so that any
+ * unhandled errors are thrown instead of forwarded to the error
+ * handler. This is useful because it's extremely common to run
+ * generators at the top-level to work with libraries.
+ */
+Q.spawn = spawn;
+function spawn(makeGenerator) {
+    Q.done(Q.async(makeGenerator)());
+}
+
 // FIXME: Remove this interface once ES6 generators are in SpiderMonkey.
 /**
  * Throws a ReturnValue exception to stop an asynchronous generator.


### PR DESCRIPTION
It's very, very common to use ES6 generators at the top-level when you don't want to continue chaining promises, and you want any errors to be thrown. The key factor is that since _all_ errors are suppressed, even language-level ones, it's too easy to forget to call done() when using generators since promises are more implicit now.

I'd say the most common case for ES6 generators is at the top-level that consume other libraries.

I will add more tests and be more thorough about this if this is at least approved to be merged. (I added a test within examples though)
