### PR TITLE
Implement `Q.dedomrequest`

### DIFF
--- a/q.js
+++ b/q.js
@@ -1713,6 +1713,27 @@ function nodeify(promise, nodeback) {
     }
 }
 
+/**
+ * Wraps a DOMRequest-producing function and returns an equivalent version that
+ * returns a promise.
+ */
+Q.dedomrequest = dedomrequest;
+function dedomrequest(fn) {
+    var baseArgs = array_slice(arguments, 1);
+    return function() {
+        var requestArgs = baseArgs.concat(array_slice(arguments));
+        var deferred = defer();
+        var request = fn.apply(null, requestArgs);
+        request.onsuccess = function() {
+            deferred.resolve(request.result);
+        };
+        request.onerror = function() {
+            deferred.reject(request.error);
+        };
+        return deferred.promise;
+    };
+}
+
 // All code before this point will be filtered from stack traces.
 var qEndingLine = captureLine();
 

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -2130,6 +2130,70 @@ describe("node support", function () {
 
     });
 
+    describe("dedomrequest", function () {
+
+        it("resolves with a successful request's 'result'", function () {
+            var spy = jasmine.createSpy();
+            Q.dedomrequest(function(original) {
+                var request = {};
+                setTimeout(function() {
+                    request.result = original + 1;
+                    request.onsuccess();
+                }, 0);
+                return request;
+            }).call(null, 9).then(spy);
+
+            waitsFor(function () {
+                return spy.argsForCall.length;
+            });
+
+            runs(function() {
+                expect(spy.argsForCall).toEqual([[10]]);
+            });
+        });
+
+        it("rejects with a failed request's 'error'", function () {
+            var spy = jasmine.createSpy();
+            Q.dedomrequest(function(original) {
+                var request = {};
+                setTimeout(function() {
+                    request.error = original + 1;
+                    request.onerror();
+                }, 0);
+                return request;
+            }).call(null, 9).then(null, spy);
+
+            waitsFor(function () {
+                return spy.argsForCall.length;
+            });
+
+            runs(function() {
+                expect(spy.argsForCall).toEqual([[10]]);
+            });
+        });
+
+        it("binds arguments specified at creation time", function () {
+            var spy = jasmine.createSpy();
+            Q.dedomrequest(function(first, second, third) {
+                var request = {};
+                setTimeout(function() {
+                    request.result = first + second + third;
+                    request.onsuccess();
+                }, 0);
+                return request;
+            }, 1).call(null, 2, 3).then(spy);
+
+            waitsFor(function () {
+                return spy.argsForCall.length;
+            });
+
+            runs(function() {
+                expect(spy.argsForCall).toEqual([[6]]);
+            });
+        });
+
+    });
+
 });
 
 describe("isPromise", function () {


### PR DESCRIPTION
I'm doing some work with Firefox OS, and many of the Gecko APIs there return a [DOMRequest object](https://developer.mozilla.org/en-US/docs/Web/API/DOMRequest). This seems ripe for promisification a la [`Q.denodeify`](https://github.com/kriskowal/q/wiki/API-Reference#qdenodeifynodefunc-args), especially considering [recent discussion to bridge DOMRequest APIs to DOMFuture](https://groups.google.com/forum/?fromgroups#!topic/mozilla.dev.webapi/q2I0SZzRC-c). Is there a place for this in Q?

Commit message:

> This method method wraps DOMRequest[1]-producing functions and returns
> equivalent versions that returns a promise.
> 
> [1] https://developer.mozilla.org/en-US/docs/Web/API/DOMRequest
