### PR TITLE
Add some clarification to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,9 +684,10 @@ return Q.fcall(function () {
 ### Adapting Node
 
 If you're working with functions that make use of the Node.js callback pattern,
-Q provides a few useful utility functions for converting between them. The
-most straightforward are probably `Q.nfcall` and `Q.nfapply` ("Node function
-call/apply") for calling Node.js-style functions and getting back a promise:
+where callbacks are in the form of `function(err, result)`, Q provides a few
+useful utility functions for converting between them. The most straightforward
+are probably `Q.nfcall` and `Q.nfapply` ("Node function call/apply") for calling
+Node.js-style functions and getting back a promise:
 
 ```javascript
 return Q.nfcall(FS.readFile, "foo.txt", "utf-8");


### PR DESCRIPTION
I spent a fair amount of time wondering why readline.question wasn't working with Q.nfcall. It turns out it's because readline.question can't raise an error, and so the function's signature is `function(result)`. I just added a short bit of clarification to make it easy for the next guy to see what 'node-style callback' means.
