### PR TITLE
Updated Q.async to work with current ES6 generators without send()

### DIFF
--- a/q.js
+++ b/q.js
@@ -1207,7 +1207,7 @@ Q.async = function (makeGenerator) {
             }
         }
         var generator = makeGenerator.apply(this, arguments);
-        var callback = continuer.bind(continuer, "send");
+        var callback = continuer.bind(continuer, "next");
         var errback = continuer.bind(continuer, "throw");
         return callback();
     };


### PR DESCRIPTION
Generators in the current ES6 spec [no longer have a `send()`](https://bugs.ecmascript.org/show_bug.cgi?id=1555) method, it's replaced with with `next(value)`: the `next()` method called with a value.

Updated the Q.async implementation to work with current ES6 spec (version in node 0.11.3 with --harmony-generators). 
