### PR TITLE
(v1.0) Postpone coercion to time-of-use

### DIFF
--- a/q.js
+++ b/q.js
@@ -572,6 +572,10 @@ function defer() {
 
         acceptedValue = value;
 
+        if (isPromise(acceptedValue)) {
+            adopt();
+        }
+
         // dispatch queued messages, if any
         if (messages.length) {
             adopt();


### PR DESCRIPTION
Regarding #369

Among other things, if Q wraps a thenable, this postpones coercion until
the consumer attempts to use the promise.  Before, `Q(thenable)` would
call `thenable.then` as soon as possible, but now the user must go all
the way to `Q(thenable).then()` in order for `thenable.then()` to be
invoked.  This is less surprising in principle.

This is achived by adding an "accepted" state to deferred promises,
between "pending" and "resolved".  This state is reflected by
`deferred.promise.inspect()`.

This change breaks many specs, which need to be reviewed and probably
fixed.
