### PR TITLE
Fixed issue when using custom RequireJS loader

### DIFF
--- a/q.js
+++ b/q.js
@@ -40,6 +40,9 @@
         bootstrap("promise", definition);
 
     // CommonJS
+    // - custom setup of RequireJS provides 'exports' variable without 'module'
+    //   function loadExtension @
+    //   https://github.com/adobe/brackets/blob/master/src/utils/ExtensionLoader.js
     } else if (typeof module !== "undefined" && typeof exports === "object") {
         module.exports = definition();
 


### PR DESCRIPTION
I ran into a problem that `exports` variable was defined but `module` wasn't when using a customized RequireJS loader (https://github.com/zaggino/brackets-git/issues/7). This fixes that. 
