### PR TITLE
(v1.0) Use WeakMap for internal branding and dispatching

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,13 +16,16 @@
    `release/q.js`, which is suitable for use as a `<script>`, and
    `release/amd/q.js`, which is suitable for use as an AMD module.  All
    new versions will be published to S3.
- - :warning: Q now depends on a WeakMap shim.  If you are using an AMD
-   loader, you will need to bring in https://github.com/drses/weak-map.
-   If you are using Q as a `<script>`, this has been embedded in the
-   release.  If you are using Q in Node.js, the dependency is taken care
-   of by NPM.
+ - :warning: Q now depends on an ASAP package and a WeakMap shim.  If
+   you are using an AMD loader, you will need to bring in
+   https://github.com/kriskowal/asap and
+   https://github.com/drses/weak-map.  If you are using Q as a
+   `<script>`, this has been embedded in the release.  If you are using
+   Q in Node.js, the dependency is taken care of by NPM.
  - :warning: `Q.nextTick` is no longer supported.  Please use `asap`
    from the `asap` package directly.
+ - :warning: `valueOf` has been removed.  Please use `inspect().value`
+   instead.
 
 ## 0.9.7
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "teleport": ">=0.2.0"
   },
   "dependencies": {
-    "asap": "~1.0.0"
+    "asap": "~1.0.0",
+    "weak-map": "~1.0.0"
   },
   "devDependencies": {
     "jshint": "~2.1.9",

--- a/q.js
+++ b/q.js
@@ -39,43 +39,17 @@ try {
 var qStartingLine = captureLine();
 var qFileName;
 
-// shims
+var asap = require("asap");
+var WeakMap = require("weak-map");
 
 // used for fallback in "allResolved"
 var noop = function () {};
-
-var asap = require("asap");
-
-// Attempt to make generics safe in the face of downstream
-// modifications.
-// There is no situation where this is necessary.
-// If you need a security guarantee, these primordials need to be
-// deeply frozen anyway, and if you don’t need a security guarantee,
-// this is just plain paranoid.
-// However, this does have the nice side-effect of reducing the size
-// of the code by reducing x.call() to merely x(), eliminating many
-// hard-to-minify characters.
-// See Mark Miller’s explanation of what this does.
-// http://wiki.ecmascript.org/doku.php?id=conventions:safe_meta_programming
-var call = Function.call;
-function uncurryThis(f) {
-    return function () {
-        return call.apply(f, arguments);
-    };
-}
-// This is equivalent, but slower:
-// uncurryThis = Function_bind.bind(Function_bind.call);
-// http://jsperf.com/uncurrythis
-
-var array_slice = uncurryThis(Array.prototype.slice);
 
 var object_create = Object.create || function (prototype) {
     function Type() { }
     Type.prototype = prototype;
     return new Type();
 };
-
-var object_toString = uncurryThis(Object.prototype.toString);
 
 function isObject(value) {
     return value === Object(value);
@@ -133,7 +107,7 @@ function makeStackTraceLong(error, promise) {
         error.stack.indexOf(STACK_JUMP_SEPARATOR) === -1
     ) {
         var stacks = [];
-        for (var p = promise; !!p; p = p.source) {
+        for (var p = promise; !!p; p = handlers.get(p).became) {
             if (p.stack) {
                 stacks.unshift(p.stack);
             }
@@ -232,8 +206,9 @@ function deprecate(callback, name, alternative) {
     };
 }
 
-// end of shims
-// beginning of real work
+// end of long stack traces
+
+var handlers = new WeakMap();
 
 /**
  * Constructs a promise for an immediate reference, passes promises through, or
@@ -258,6 +233,32 @@ function Q(value) {
 Q.resolve = Q;
 
 /**
+ * TODO
+ */
+function getHandler(promise) {
+    var handler = handlers.get(promise);
+    if (!handler || !handler.became) {
+        return handler;
+    }
+    handler = followHandler(handler);
+    handlers.set(promise, handler);
+    return handler;
+}
+
+function followHandler(handler) {
+    if (!handler.became) {
+        return handler;
+    } else {
+        handler.became = followHandler(handler.became);
+        return handler.became;
+    }
+}
+
+var theViciousCycleError = new Error("Can't resolve a promise with itself");
+var theViciousCycleRejection = reject(theViciousCycleError);
+var theViciousCycleHandler = getHandler(theViciousCycleRejection);
+
+/**
  * Controls whether or not long stack traces will be on
  */
 Q.longStackSupport = false;
@@ -280,43 +281,24 @@ function defer() {
     // forward to the resolved promise.  We coerce the resolution value to a
     // promise using the `resolve` function because it handles both fully
     // non-thenable values and other thenables gracefully.
-    var messages = [], progressListeners = [], resolvedPromise;
+    var messages = [], progressListeners = [];
 
     var deferred = object_create(defer.prototype);
     var promise = object_create(Promise.prototype);
 
-    promise.promiseDispatch = function (resolve, op, operands) {
-        var args = array_slice(arguments);
-        if (messages) {
-            messages.push(args);
+    var handler = {
+        dispatch: function (resolve, op, operands) {
+            messages.push([resolve, op, operands]);
             if (op === "when" && operands[1]) { // progress operand
                 progressListeners.push(operands[1]);
             }
-        } else {
-            asap(function () {
-                resolvedPromise.promiseDispatch.apply(resolvedPromise, args);
-            });
-        }
-    };
-
-    // XXX deprecated
-    promise.valueOf = deprecate(function () {
-        if (messages) {
-            return promise;
-        }
-        var nearerValue = nearer(resolvedPromise);
-        if (isPromise(nearerValue)) {
-            resolvedPromise = nearerValue; // shorten chain
-        }
-        return nearerValue;
-    }, "valueOf", "inspect");
-
-    promise.inspect = function () {
-        if (!resolvedPromise) {
+        },
+        inspect: function () {
             return { state: "pending" };
         }
-        return resolvedPromise.inspect();
     };
+
+    handlers.set(promise, handler);
 
     if (Q.longStackSupport && hasStacks) {
         try {
@@ -332,17 +314,20 @@ function defer() {
         }
     }
 
-    // NOTE: we do the checks for `resolvedPromise` in each method, instead of
-    // consolidating them into `become`, since otherwise we'd create new
-    // promises with the lines `become(whatever(value))`. See e.g. GH-252.
-
     function become(newPromise) {
-        resolvedPromise = newPromise;
-        promise.source = newPromise;
+        handler.became = theViciousCycleHandler;
+        var newHandler = getHandler(newPromise);
+        handler.became = newHandler;
+
+        handlers.set(promise, newHandler);
+        handler = void 0; // A dead resolver should not retain dead objects
+        promise = void 0;
 
         messages.forEach(function (message) {
+            // TODO figure out whether this asap is necessary.  makeQ does not
+            // have it.
             asap(function () {
-                newPromise.promiseDispatch.apply(newPromise, message);
+                newHandler.dispatch.apply(void 0, message);
             });
         });
 
@@ -351,30 +336,25 @@ function defer() {
     }
 
     deferred.promise = promise;
+
     deferred.resolve = function (value) {
-        if (resolvedPromise) {
+        if (!messages) {
             return;
         }
 
         become(Q(value));
     };
 
-    deferred.fulfill = function (value) {
-        if (resolvedPromise) {
-            return;
-        }
-
-        become(fulfill(value));
-    };
     deferred.reject = function (reason) {
-        if (resolvedPromise) {
+        if (!messages) {
             return;
         }
 
         become(reject(reason));
     };
+
     deferred.notify = function (progress) {
-        if (resolvedPromise) {
+        if (!messages) {
             return;
         }
 
@@ -516,43 +496,33 @@ function Promise(descriptor, fallback, inspect) {
 
     var promise = object_create(Promise.prototype);
 
-    promise.promiseDispatch = function (resolve, op, args) {
-        var result;
-        try {
-            if (descriptor[op]) {
-                result = descriptor[op].apply(promise, args);
-            } else {
-                result = fallback.call(promise, op, args);
+    var handler = {
+        dispatch: function (resolve, op, operands) {
+            var result;
+            try {
+                if (descriptor[op]) {
+                    result = descriptor[op].apply(promise, operands);
+                } else {
+                    result = fallback.call(promise, op, operands);
+                }
+            } catch (exception) {
+                result = reject(exception);
             }
-        } catch (exception) {
-            result = reject(exception);
-        }
-        if (resolve) {
-            resolve(result);
-        }
+            if (resolve) {
+                resolve(result);
+            }
+        },
+        inspect: inspect
     };
 
-    promise.inspect = inspect;
-
-    // XXX deprecated `valueOf` and `exception` support
-    if (inspect) {
-        var inspected = inspect();
-        if (inspected.state === "rejected") {
-            promise.exception = inspected.reason;
-        }
-
-        promise.valueOf = deprecate(function () {
-            var inspected = inspect();
-            if (inspected.state === "pending" ||
-                inspected.state === "rejected") {
-                return promise;
-            }
-            return inspected.value;
-        });
-    }
+    handlers.set(promise, handler);
 
     return promise;
 }
+
+Promise.prototype.inspect = function () {
+    return getHandler(this).inspect();
+};
 
 Promise.prototype.toString = function () {
     return "[object Promise]";
@@ -589,7 +559,7 @@ Promise.prototype.then = function (fulfilled, rejected, progressed) {
     }
 
     asap(function () {
-        self.promiseDispatch(function (value) {
+        getHandler(self).dispatch(function (value) {
             if (done) {
                 return;
             }
@@ -607,7 +577,7 @@ Promise.prototype.then = function (fulfilled, rejected, progressed) {
     });
 
     // Progress propagator need to be attached in the current tick.
-    self.promiseDispatch(void 0, "when", [void 0, function (value) {
+    getHandler(this).dispatch(void 0, "when", [void 0, function (value) {
         var newValue;
         var threw = false;
         try {
@@ -694,9 +664,7 @@ function nearer(value) {
  */
 Q.isPromise = isPromise;
 function isPromise(object) {
-    return isObject(object) &&
-        typeof object.promiseDispatch === "function" &&
-        typeof object.inspect === "function";
+    return isObject(object) && !!handlers.get(object);
 }
 
 Q.isPromiseAlike = isPromiseAlike;
@@ -710,11 +678,11 @@ function isPromiseAlike(object) {
  */
 Q.isPending = isPending;
 function isPending(object) {
-    return isPromise(object) && object.inspect().state === "pending";
+    return Q(object).isPending();
 }
 
 Promise.prototype.isPending = function () {
-    return this.inspect().state === "pending";
+    return getHandler(this).inspect().state === "pending";
 };
 
 /**
@@ -1102,10 +1070,10 @@ function dispatch(object, op, args) {
 }
 
 Promise.prototype.dispatch = function (op, args) {
-    var self = this;
     var deferred = defer();
+    var self = this;
     asap(function () {
-        self.promiseDispatch(deferred.resolve, op, args);
+        getHandler(self).dispatch(deferred.resolve, op, args);
     });
     return deferred.promise;
 };


### PR DESCRIPTION
Using WeakMap to connect promises with their corresponding handlers
provides a much stronger “brand” for promises created by a particular
instance of Q.  Previously, we used the `promiseDispatch` duck type to
distinguish Q promises from other kinds of promise in the wild, but were
unable to distinguish a promise from another instance of Q, even from a
different version of Q.  This led to subtle bugs, especially when we
changed the promise interface to include `inspect`.

This introduces WeakMap and cribs small but insightful parts from Mark
Miller’s `makeQ`.

However, these changes cause various specs to fail, mostly pertaining to
the order in which progress notifications are dispatched.

The code for managing progress notifications, in its current state, is
worrying.  It appears that it was necessary to dispatch a "when" message
synchronously in the "then" method to attach promise handlers,
presumably so we would be able to listen for notifications in the same
turn the promise was constructed.  It seems that a symmetric change, to
dispatch notifications synchronously, solves the ordering problem.
However, synchronous registration and synchronous dispatch both
introduce plan interference hazards.  The consumer of a notification and
can interfere, and inspect the stack of, the producer of a progress
notification.

My intuition is that the specs are wrong and that we will need to relax
our guarantees about whether and when a progress notification will be
received.  As such, this needs further review.
