### PR TITLE
Opt-in unhandled rejection tracking

### DIFF
--- a/q.js
+++ b/q.js
@@ -949,7 +949,6 @@ function displayUnhandledReasons() {
     if (
         !unhandledReasonsDisplayed &&
         typeof window !== "undefined" &&
-        !window.Touch &&
         window.console
     ) {
         console.warn("[Q] Unhandled rejection reasons (should be empty):",


### PR DESCRIPTION
Current implementation requires a browser able to live update an array that has been printed with `console.warn()`, otherwise the "Unhandled rejection reasons (should be empty)" turns to be very confusing because it's not empty when the message is printed.

Because currently there isn't any reliable way to detect whether the browser supports it, maybe it's better to make this feature an opt-in option.

Current behaviour with last versions of the following browsers:
- Firefox and Safari behave as expected.
- Chrome is not printing anything (cause `window.Touch` is defined).
- PhantomJS is printing the mentioned warning, resulting in a upsetting experience.
