### PR TITLE
(v0.9) window.Touch no longer reliable differentiator

### DIFF
--- a/q.js
+++ b/q.js
@@ -984,7 +984,6 @@ function displayUnhandledReasons() {
     if (
         !unhandledReasonsDisplayed &&
         typeof window !== "undefined" &&
-        !window.Touch &&
         window.console
     ) {
         console.warn("[Q] Unhandled rejection reasons (should be empty):",


### PR DESCRIPTION
Console logging was previously disabled for tablets and phones (for
reasons I no longer recall) using `window.Touch` to distinguish them
from other platforms.  This is no longer a valid distinction since
non-phone / non-tablet browsers are beginning to expose the name space
regardless of whether the host envirionment supports touch events.

(Against legacy 0.9 branch)
