### PR TITLE
Do not modify input array of Q.all

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ## 1.0.0
 
  - :warning: Withdrew support for SpiderMonkey style generators.
+ - :warning: `Q.all` no longer reuses the input array for the output
+   array.
 
 ## 0.9.7
 

--- a/q.js
+++ b/q.js
@@ -1389,21 +1389,22 @@ function all(promises) {
     return when(promises, function (promises) {
         var countDown = 0;
         var deferred = defer();
+        var answers = Array(promises.length);
         array_reduce(promises, function (undefined, promise, index) {
             var snapshot;
             if (
                 isPromise(promise) &&
                 (snapshot = promise.inspect()).state === "fulfilled"
             ) {
-                promises[index] = snapshot.value;
+                answers[index] = snapshot.value;
             } else {
                 ++countDown;
                 when(
                     promise,
                     function (value) {
-                        promises[index] = value;
+                        answers[index] = value;
                         if (--countDown === 0) {
-                            deferred.resolve(promises);
+                            deferred.resolve(answers);
                         }
                     },
                     deferred.reject,
@@ -1414,7 +1415,7 @@ function all(promises) {
             }
         }, void 0);
         if (countDown === 0) {
-            deferred.resolve(promises);
+            deferred.resolve(answers);
         }
         return deferred.promise;
     });

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -1128,12 +1128,12 @@ describe("all", function () {
         });
     });
 
-    it("modifies the input array", function () {
+    it("does not modify the input array", function () {
         var input = [Q(0), Q(1)];
 
         return Q.all(input).then(function (result) {
-            expect(result).toBe(input);
-            expect(input).toEqual([0, 1]);
+            expect(result).not.toBe(input);
+            expect(input).not.toEqual([0, 1]);
         });
     });
 


### PR DESCRIPTION
It was a bad idea. Since we’re targeting a backward-incompatible major release, let’s land it.
