### PR TITLE
Make thenables inspectable

### DIFF
--- a/q.js
+++ b/q.js
@@ -1123,6 +1123,12 @@ function ThenableHandler(thenable) {
     this.became = null;
 }
 
+ThenableHandler.prototype.state = "thenable";
+
+ThenableHandler.prototype.inspect = function () {
+    return {state: "thenable"};
+};
+
 ThenableHandler.prototype.cast = function () {
     if (!this.became) {
         var deferred = defer();

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -1737,6 +1737,21 @@ describe("thenReject", function () {
 
 describe("thenables", function () {
 
+    it("can be inspected", function () {
+        var promise = Q({then: function (resolved) {
+            resolved(10);
+        }});
+        expect(promise.inspect()).toEqual({state: "thenable"});
+        var newPromise = promise.then(function (n) {
+            return n * 2;
+        });
+        expect(promise.inspect()).toEqual({state: "pending"});
+        return newPromise.then(function (n) {
+            expect(newPromise.inspect()).toEqual({state: "fulfilled", value: 20});
+            expect(n).toBe(20);
+        });
+    });
+
     it("assimilates a thenable with fulfillment with resolve", function () {
         return Q({
             then: function (resolved) {


### PR DESCRIPTION
I expect there to be debate about this proposed behavior. Without this patch, inspect on a thenable throws an error, so we need some reasonable behavior, and it will need to match what is observable with promises-as-speced.
