### PR TITLE
Fixed bug in Q.async yield

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "mr": "~0.13.3"
   },
   "scripts": {
-    "test": "jasmine-node spec && promises-aplus-tests spec/aplus-adapter",
+    "test": "node --harmony node_modules/jasmine-node/lib/jasmine-node/cli.js spec && promises-aplus-tests spec/aplus-adapter",
     "release": "grunt release",
     "benchmark": "matcha",
     "lint": "jshint q.js",

--- a/q.js
+++ b/q.js
@@ -515,7 +515,7 @@ function async(makeGenerator) {
             }
         }
         var generator = makeGenerator.apply(this, arguments);
-        var callback = continuer.bind(continuer, "next");
+        var callback = continuer.bind(continuer, "send");
         var errback = continuer.bind(continuer, "throw");
         return callback();
     };

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -192,6 +192,14 @@ describe("always next tick", function () {
 
 });
 
+describe("async generators", function () {
+    it("returns the promise value", function () {
+        return Q.async(function *() {
+            expect(yield Q(42)).toEqual(42);
+        })();
+    });
+});
+
 xdescribe("progress", function () {
 
     it("calls a single progress listener", function () {


### PR DESCRIPTION
See the unit test I added for an example of this bug.

`Q.async` allows the use of `yield`. Unfortunately, the value of the previous expression is not returned, that is, the return value of the yield expression is always `undefined`.

So instead of

``` javascript
var value = yield doSomething();
```

We'd have to use

``` javascript
var promise = doSomething();
yield promise;
var value = promise.inspect().value;
```

Which is cumbersome.

This commit fixes this problem.

To properly test the problem, I had to switch jasmine-node to harmony mode. If this is a problem, I could try to rewrite the test to use plain old JS functions.
