### PR TITLE
Adding Q.isDeferred

### DIFF
--- a/q.js
+++ b/q.js
@@ -265,6 +265,14 @@ function defer() {
 }
 
 /**
+ * @returns whether the given object is a Q Deferred.
+ */
+Q.isDeferred = isDeferred;
+function isDeferred(object) {
+    return isObject(object) && object instanceof Deferred;
+}
+
+/**
  * Turns an array of promises into a promise for an array.  If any of
  * the promises gets rejected, the whole array is rejected immediately.
  * @param {Array*} an array (or promise for an array) of values (or

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -2106,6 +2106,25 @@ describe("isPromise", function () {
     });
 });
 
+describe("isDeferred", function () {
+    it("returns true if passed a Deferred", function () {
+        expect(Q.isDeferred(Q.defer())).toBe(true);
+    });
+
+    it("returns false if not passed a Deferred", function () {
+        expect(Q.isDeferred()).toBe(false);
+        expect(Q.isDeferred(undefined)).toBe(false);
+        expect(Q.isDeferred(null)).toBe(false);
+        expect(Q.isDeferred(true)).toBe(false);
+        expect(Q.isDeferred('str')).toBe(false);
+        expect(Q.isDeferred(42)).toBe(false);
+        expect(Q.isDeferred({})).toBe(false);
+        expect(Q.isDeferred([])).toBe(false);
+        expect(Q.isDeferred(/a/g)).toBe(false);
+        expect(Q.isDeferred(Q(42))).toBe(false);
+    });
+});
+
 describe("isThenable", function () {
     it("returns true if passed a promise like object", function () {
         expect(Q.isThenable(Q(10))).toBe(true);


### PR DESCRIPTION
Per https://twitter.com/kriskowal/status/417718297333747713:

Q doesn't expose the raw `Deferred` constructor, so the only way I found to determine if an object is a Q Deferred without ducktyping was `deferred instanceof Q.defer().constructor`. This makes the Deferred-related APIs more consistent with the Promise-related ones, a la isPromise.

My use case: I'm writing another module, and I want to write tests that ensure a method returns a Deferred. I can't do that without a way to verify that it's a Deferred or not.
