### PR TITLE
Flip then and done

### DIFF
--- a/test/never-again.js
+++ b/test/never-again.js
@@ -23,14 +23,15 @@ describe("gh-22", function () {
 
 describe("gh-73", function () {
     it("does not choke on non-error rejection reasons", function (done) {
-        Q.reject(REASON).done();
-
-        var deferred = Q.defer();
-
         Q.onerror = function (error) {
             expect(error).is(REASON);
             deferred.resolve();
         };
+
+        Q.reject(REASON).done();
+
+        var deferred = Q.defer();
+
         Q.delay(10).then(deferred.reject);
 
         deferred.promise.done(done, done);
@@ -39,16 +40,17 @@ describe("gh-73", function () {
 
 describe("gh-90", function () {
     it("does not choke on rejection reasons with an undefined `stack`", function (done) {
+        Q.onerror = function (theError) {
+            expect(theError).is(error);
+            deferred.resolve();
+        };
+
         var error = new RangeError(REASON);
         error.stack = undefined;
         Q.reject(error).done();
 
         var deferred = Q.defer();
 
-        Q.onerror = function (theError) {
-            expect(theError).is(error);
-            deferred.resolve();
-        };
         Q.delay(10).then(deferred.reject);
 
         deferred.promise.done(done, done);

--- a/test/q.js
+++ b/test/q.js
@@ -999,6 +999,13 @@ describe("done", function () {
         describe("and the callback throws", function () {
 
             it("should rethrow that error in the next turn and return nothing", function (done) {
+                Q.onerror = function (error) {
+                    expect(turn).is(1);
+                    expect(error).is("foo");
+                    expect(returnValue).is(undefined);
+                    deferred.resolve();
+                };
+
                 var turn = 0;
                 asap(function () {
                     ++turn;
@@ -1011,12 +1018,6 @@ describe("done", function () {
                 );
 
                 var deferred = Q.defer();
-                Q.onerror = function (error) {
-                    expect(turn).is(1);
-                    expect(error).is("foo");
-                    expect(returnValue).is(undefined);
-                    deferred.resolve();
-                };
                 Q.delay(100).then(deferred.reject);
 
                 return deferred.promise.done(done, done);
@@ -1057,6 +1058,13 @@ describe("done", function () {
         describe("and the errback throws", function () {
 
             it("should rethrow that error in the next turn and return nothing", function (done) {
+                Q.onerror = function (error) {
+                    expect(turn).is(1);
+                    expect(error).is("foo");
+                    expect(returnValue).is(undefined);
+                    deferred.resolve();
+                };
+
                 var turn = 0;
                 asap(function () {
                     ++turn;
@@ -1070,12 +1078,6 @@ describe("done", function () {
                 );
 
                 var deferred = Q.defer();
-                Q.onerror = function (error) {
-                    expect(turn).is(1);
-                    expect(error).is("foo");
-                    expect(returnValue).is(undefined);
-                    deferred.resolve();
-                };
                 Q.delay(100).then(deferred.reject);
 
                 deferred.promise.done(done, done);
@@ -1085,6 +1087,13 @@ describe("done", function () {
         describe("and there is no errback", function () {
 
             it("should throw the original error in the next turn", function (done) {
+                Q.onerror = function (error) {
+                    expect(turn).is(1);
+                    expect(error).is("bar");
+                    expect(returnValue).is(undefined);
+                    deferred.resolve();
+                };
+
                 var turn = 0;
                 asap(function () {
                     ++turn;
@@ -1093,12 +1102,6 @@ describe("done", function () {
                 var returnValue = Q.reject("bar").done();
 
                 var deferred = Q.defer();
-                Q.onerror = function (error) {
-                    expect(turn).is(1);
-                    expect(error).is("bar");
-                    expect(returnValue).is(undefined);
-                    deferred.resolve();
-                };
                 Q.delay(10).then(deferred.reject);
 
                 deferred.promise.done(done, done);

--- a/test/traces.js
+++ b/test/traces.js
@@ -8,15 +8,16 @@ describe("stack trace formatting", function () {
         if (!new Error("").stack) {
             return done();
         }
+
+        Q.onerror = function (err) {
+            captured.put(err.stack);
+        };
+
         var d1 = Q.defer();
         var d2 = Q.defer();
         var captured = new Queue();
         d1.promise.done();
         d2.promise.done();
-
-        Q.onerror = function (err) {
-            captured.put(err.stack);
-        };
 
         var error = new Error("boom!");
         d1.reject(error);


### PR DESCRIPTION
That is to say, implement `then` in terms of `done` instead of `done` in
terms of `then`. This makes quite a bit of sense since `done` can be
less expensive since it does not need to construct an intermediate
promise.

This factoring also creates special cases to avoid unnecessary try/catch
clauses by checking for `Q.onerror` up front. Thus, this is slightly
backward incompatible. `Q.onerror` must have been set before `done` or
`then` are called for errors to be trapped.
