### PR TITLE
Ability to identify timeout errors

### DIFF
--- a/q.js
+++ b/q.js
@@ -1670,18 +1670,22 @@ Promise.prototype.done = function (fulfilled, rejected, progress) {
  * some milliseconds time out.
  * @param {Any*} promise
  * @param {Number} milliseconds timeout
- * @param {String} custom error message (optional)
+ * @param {Any*} custom error message or Error object (optional)
  * @returns a promise for the resolution of the given promise if it is
  * fulfilled before the timeout, otherwise rejected.
  */
-Q.timeout = function (object, ms, message) {
-    return Q(object).timeout(ms, message);
+Q.timeout = function (object, ms, error) {
+    return Q(object).timeout(ms, error);
 };
 
-Promise.prototype.timeout = function (ms, message) {
+Promise.prototype.timeout = function (ms, error) {
     var deferred = defer();
     var timeoutId = setTimeout(function () {
-        deferred.reject(new Error(message || "Timed out after " + ms + " ms"));
+        if (!error || "string" === typeof error) {
+            error = new Error(error || "Timed out after " + ms + " ms");
+            error.code = "ETIMEDOUT";
+        }
+        deferred.reject(error);
     }, ms);
 
     this.then(function (value) {

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -1634,10 +1634,26 @@ describe("timeout", function () {
             },
             function (error) {
                 expect(/custom/i.test(error.message)).toBe(true);
+                expect(error.code).toBe("ETIMEDOUT");
             }
         );
     });
 
+    it("should reject with a custom timeout error if the promise is too slow and Error object was provided", function () {
+        var customError = new Error("custom");
+        customError.isCustom = true;
+        return Q.delay(100)
+        .timeout(10, customError)
+        .then(
+            function () {
+                expect(true).toBe(false);
+            },
+            function (error) {
+                expect(/custom/i.test(error.message)).toBe(true);
+                expect(error.isCustom).toBe(true);
+            }
+        );
+    });
 
 });
 


### PR DESCRIPTION
Allows `Q.timeout` message to be a custom `Error` object or sets `error.code == 'ETIMEDOUT'`.

Fixes #513
