### PR TITLE
Q.async()'s return should not treat thenables special

### DIFF
--- a/q.js
+++ b/q.js
@@ -1193,7 +1193,7 @@ function async(makeGenerator) {
                     return reject(exception);
                 }
                 if (result.done) {
-                    return Q(result.value);
+                    return fulfill(result.value);
                 } else {
                     return when(result.value, callback, errback);
                 }
@@ -1204,7 +1204,7 @@ function async(makeGenerator) {
                     result = generator[verb](arg);
                 } catch (exception) {
                     if (isStopIteration(exception)) {
-                        return Q(exception.value);
+                        return fulfill(exception.value);
                     } else {
                         return reject(exception);
                     }


### PR DESCRIPTION
#499 fixed a bug, but introduced another one:

```
var Q = require('q');
var test = Q.async(function*() {
    return Q(123);
});
test().then(console.log);
```

prints `123`, but should print `{ state: "fulfilled", value: 123 }`.

**Why should it print the promise?**

`async` should not guess on the return value, but instead provide a static, reliable semantic that chains all `yield`ed promises, and finally resolves in the returned value - no matter what the returned value is.

I stumbled upon this bug because I have a class `Task` that derives from `Promise`, and I needed to return the task (and not wait until the task itself is fulfilled).

**Where is the bug located?**

`async` calls [`Q()`](https://github.com/kriskowal/q/blob/v1/q.js#L449), wich does some magic typeguessing with the parameter, i.e. if the parameter is a promise, it does not wrap it in a promise as it does with other values.

It would be awesome if you could deploy a bugfix release after merging this.
