### PR TITLE
fix handling of array argument to makeNodeResolver

### DIFF
--- a/q.js
+++ b/q.js
@@ -1522,7 +1522,7 @@ Deferred.prototype.makeNodeResolver = function (unpack) {
                 resolve(Q_reject(error));
             } else {
                 var value = {};
-                for (var index in unpack) {
+                for (var index = 0; index < unpack.length; index++) {
                     value[unpack[index]] = arguments[index + 1];
                 }
                 resolve(value);

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -234,6 +234,32 @@ describe("node support", function () {
             .done(done, done);
         });
 
+        it("provides arguments as array given true", function (done) {
+            var deferred = Q.defer();
+            var callback = deferred.makeNodeResolver(true);
+            callback(null, 3, 4, 5);
+            deferred.promise.then(function (value) {
+                expect(value.length).toBe(3);
+                expect(value[0]).toBe(3);
+                expect(value[1]).toBe(4);
+                expect(value[2]).toBe(5);
+            })
+            .done(done, done);
+        });
+
+        it("provides arguments as object given array of names", function (done) {
+            var deferred = Q.defer();
+            var callback = deferred.makeNodeResolver(["x", "y", "z"]);
+            callback(null, 3, 4, 5);
+            deferred.promise.then(function (value) {
+                expect(Object.keys(value).length).toBe(3);
+                expect(value.x).toBe(3);
+                expect(value.y).toBe(4);
+                expect(value.z).toBe(5);
+            })
+            .done(done, done);
+        });
+
     });
 
     describe("nodeify", function () {


### PR DESCRIPTION
With for…in enumeration the indexes are given as strings, and `"0" + 1` gives `"01"` rather than `1`. Switching to a regular for loop is a solution.

The handling of `true` is not broken but also lacks tests. I've included a test case for this, too.
