### PR TITLE
use instanceof to determine whether an object is a Q promise inside function Q

### DIFF
--- a/q.js
+++ b/q.js
@@ -450,7 +450,7 @@ function Q(value) {
     // If the object is already a Promise, return it directly.  This enables
     // the resolve function to both be used to created references from objects,
     // but to tolerably coerce non-promises to promises.
-    if (isPromise(value)) {
+    if (value instanceof Promise) {
         return value;
     }
 
@@ -912,7 +912,9 @@ function nearer(value) {
  */
 Q.isPromise = isPromise;
 function isPromise(object) {
-    return object instanceof Promise;
+    return isObject(object) &&
+        typeof object.promiseDispatch === "function" &&
+        typeof object.inspect === "function";
 }
 
 Q.isPromiseAlike = isPromiseAlike;


### PR DESCRIPTION
Considering modules using nested Q may have different versions or plugins (yup, such as my q-retry), I think it would be safer to determine whether the Q-promise-alike object is the instance of current Q promise constructor. So that the promise chain would be more reliable especially when promises are widely used in different modules.

This would bring a little bit performance impact, but it should be considered minor (actually only one more coerce for two modules and a single chain).
