### PR TITLE
check module is defined before adding exports (chrome extensions bug?)

### DIFF
--- a/q.js
+++ b/q.js
@@ -40,7 +40,7 @@
         bootstrap("promise", definition);
 
     // CommonJS
-    } else if (typeof exports === "object") {
+    } else if (typeof exports === "object" && typeof module != "undefined") {
         module.exports = definition();
 
     // RequireJS


### PR DESCRIPTION
on chrome extensions that I have tested, the test typeof exports === "object"  is not enough (it can pass and then reach the module.exports line that throws an exception). so I added the typeof module != "undefined" which solved the problem in the case of my chrome extension.