### PR TITLE
if stack trace is unwritable on error that shouldn't lead to a timeout

### DIFF
--- a/q.js
+++ b/q.js
@@ -347,7 +347,14 @@ function makeStackTraceLong(error, promise) {
         stacks.unshift(error.stack);
 
         var concatedStacks = stacks.join("\n" + STACK_JUMP_SEPARATOR + "\n");
-        error.stack = filterStackString(concatedStacks);
+        try {
+            error.stack = filterStackString(concatedStacks);
+        } catch (e) {
+            if (typeof console !== "undefined" &&
+                typeof console.warn === "function") {
+                console.warn("unable to create long stack trace for", error, "as stack is unwritable");
+            }
+        }
     }
 }
 

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -2504,3 +2504,33 @@ describe("unhandled rejection reporting", function () {
         expect(Q.getUnhandledReasons()).toEqual([]);
     });
 });
+describe("long stack trace support", function () {
+    beforeEach(function () {
+        Q.longStackSupport = true;
+    });
+    afterEach(function () {
+        Q.longStackSupport = false;
+    });
+    it("should throw a long stack trace");
+    it("should not break if stack is not settable", function () {
+        return Q(true).then(function(){
+            var error = new Error("ths is a demo error without a writable stack");
+            var s = error.stack;
+            delete error.stack;
+            //make stack trace read only
+            Object.defineProperty(error, "stack", {
+              configurable: true,
+              enumerable: false,
+              get: function () {
+                return s;
+              }
+            });
+            throw error;
+        }).then(function () {
+            expect(false).toEqual(true);
+
+        }).fail(function (err) {
+            expect(err.message).toEqual("ths is a demo error without a writable stack");
+        });
+    });
+});


### PR DESCRIPTION
currently if you throw an error that has an unwritable stack trace and you have longStackSupport enabled (see modules like https://www.npmjs.org/package/errors) you end up with a timeout. This shouldn't be a timeout case and should just warn that the stack wasn't able to be rewritten