### PR TITLE
Add a wrap sugar function to promises

### DIFF
--- a/q.js
+++ b/q.js
@@ -1065,6 +1065,10 @@ function fulfill(value) {
         "delete": function (name) {
             delete value[name];
         },
+        "wrap": function (wrapperObject, key) {
+            wrapperObject[key] = value;
+            return wrapperObject;
+        },
         "post": function (name, args) {
             // Mark Miller proposes that post with no name should apply a
             // promised function.
@@ -1349,6 +1353,21 @@ Q["delete"] = function (object, key) {
 Promise.prototype.del = // XXX legacy
 Promise.prototype["delete"] = function (key) {
     return this.dispatch("delete", [key]);
+};
+
+/**
+ * Wraps the promise in a wrapper object at the given key.
+ * @param value             the value of the promise
+ * @param wrapperObject     the object that wraps the promise
+ * @param key               name the promise will be assigned
+ * @return promise for the wrapper object
+ */
+Q.wrap = function (value, wrapperObject, key) {
+    return Q(value).dispatch("wrap", [wrapperObject, key]);
+};
+
+Promise.prototype.wrap = function (wrapperObject, key) {
+    return this.dispatch("wrap", [wrapperObject, key]);
 };
 
 /**

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -595,6 +595,37 @@ describe("promises for objects", function () {
 
     });
 
+    describe("wrap", function() {
+
+        it("fulfills a promise", function () {
+            var wrapperObject = {};
+            var value = "promise value";
+            var deferred = Q.defer();
+            deferred.resolve(value);
+
+            return deferred.promise.wrap(wrapperObject, "key")
+            .then(function (result) {
+                expect(result).toBe(wrapperObject);
+                expect(result.key).toBe("promise value");
+            });
+        });
+
+        it("propagates a rejection", function () {
+            var exception = new Error("boo!");
+            var wrapperObject = {};
+            return Q.fcall(function () {
+                throw exception;
+            })
+            .wrap(wrapperObject, "key")
+            .then(function () {
+                expect(true).toBe(false);
+            }, function (_exception) {
+                expect(_exception).toBe(exception);
+            });
+        });
+
+    });
+
     describe("post", function () {
 
         it("fulfills a promise", function () {


### PR DESCRIPTION
This adds a function `wrap` that is essentially a sugar method for:

```
var wrapperObject = {};
promise.then(function(value) {
    wrapperObject.key = value;
    return wrapperObject;
});
```

This becomes:

```
var wrapperObject = {};
promise.wrap(wrapperObject, 'key');
```

This function was originally written as a promisehelper function:

https://www.npmjs.org/package/promisehelpers
