### PR TITLE
add bower.json with proper exlcudes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,43 @@
+{
+  "name": "q",
+  "main": "q.js",
+  "version": "1.1.2",
+  "homepage": "https://github.com/kriskowal/q",
+  "authors": [
+    "Kris Kowal <kris@cixar.com> (https://github.com/kriskowal)"
+  ],
+  "description": "A library for promises (CommonJS/Promises/A,B,D)",
+  "moduleType": [
+    "amd",
+    "globals",
+    "node"
+  ],
+  "keywords": [
+    "q",
+    "promise",
+    "promises",
+    "promises-a",
+    "promises-aplus",
+    "deferred",
+    "future",
+    "async",
+    "flow",
+    "control",
+    "fluent",
+    "browser",
+    "node"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "*.md",
+    "Gruntfile.js",
+    "package.json",
+    "q.png",
+    "q.svg",
+    "benchmark",
+    "design",
+    "examples",
+    "spec"
+  ]
+}


### PR DESCRIPTION
When managing q through bower, the package is quite big and contains a lot of resources that are not needed for web dev/production:

```console
.
├── CHANGES.md
├── CONTRIBUTING.md
├── Gruntfile.js
├── LICENSE
├── README.md
├── VERSIONS.md
├── benchmark
│   ├── compare-with-callbacks.js
│   └── scenarios.js
├── bower.json
├── design
│   ├── README.js
│   ├── q0.js
│   ├── q1.js
│   ├── q2.js
│   ├── q3.js
│   ├── q4.js
│   ├── q5.js
│   ├── q6.js
│   └── q7.js
├── examples
│   ├── all.js
│   └── async-generators
│       ├── 0.html
│       ├── 1-return.js
│       ├── 2-error-propagation.js
│       ├── 3-spawn.js
│       ├── 4-flow-control.js
│       └── README.md
├── package.json
├── q.js
├── q.png
├── q.svg
├── queue.js
├── ref_send.md
└── spec
    ├── aplus-adapter.js
    ├── lib
    │   ├── jasmine-1.2.0
    │   │   ├── MIT.LICENSE
    │   │   ├── jasmine-html.js
    │   │   ├── jasmine.css
    │   │   └── jasmine.js
    │   └── jasmine-promise.js
    ├── q-spec.html
    ├── q-spec.js
    └── queue-spec.js
```

This PR introduces a `bower.json` with according excludes.