### PR TITLE
Better error when finally callback is invalid

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,4 @@
+ - Throw if callback supplied to "finally" is invalid (@grahamrhay)
 
 ## 1.4.1
 

--- a/q.js
+++ b/q.js
@@ -1752,6 +1752,9 @@ Q["finally"] = function (object, callback) {
 
 Promise.prototype.fin = // XXX legacy
 Promise.prototype["finally"] = function (callback) {
+    if (!callback || typeof callback.apply !== "function") {
+        throw new Error("Can't apply finally callback");
+    }
     callback = Q(callback);
     return this.then(function (value) {
         return callback.fcall().then(function () {

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -1671,6 +1671,38 @@ describe("fin", function () {
 
     });
 
+    describe("when the callback is invalid", function () {
+        describe("undefined", function () {
+            it("should have a useful error", function () {
+                var foo = {},
+                    threw = false;
+
+                try {
+                    Q().fin(foo.bar);
+                } catch (err) {
+                    expect(err.message).toBe("Can't apply finally callback");
+                    threw = true;
+                }
+
+                expect(threw).toBe(true);
+            });
+        });
+
+        describe("not a function", function () {
+            it("should have a useful error", function () {
+                var threw = false;
+
+                try {
+                    Q().fin(123);
+                } catch (err) {
+                    expect(err.message).toBe("Can't apply finally callback");
+                    threw = true;
+                }
+
+                expect(threw).toBe(true);
+            });
+        });
+    });
 });
 
 // Almost like "fin"


### PR DESCRIPTION
Supplying an invalid callback to "finally" gives a very unhelpful stacktrace:

```
TypeError: Cannot call method 'apply' of undefined
    at Promise.apply (/opt/q/q.js:1107:26)
    at Promise.promise.promiseDispatch (/opt/q/q.js:748:41)
    at /opt/q/q.js:1333:14
    at flush (/opt/q/q.js:110:17)
    at process._tickDomainCallback (node.js:463:13)
```