### PR TITLE
Add check for array parameter to Q.all()

### DIFF
--- a/q.js
+++ b/q.js
@@ -1502,6 +1502,10 @@ Promise.prototype.keys = function () {
 Q.all = all;
 function all(promises) {
     return when(promises, function (promises) {
+        if (!Array.isArray(arguments[0]) || arguments.length !== 1) {
+            throw Error("All must be passed an array of promises.");
+        }
+        
         var pendingCount = 0;
         var deferred = defer();
         array_reduce(promises, function (undefined, promise, index) {

--- a/q.js
+++ b/q.js
@@ -1308,7 +1308,7 @@ function _return(value) {
 Q.promised = promised;
 function promised(callback) {
     return function () {
-        return spread([this, all(arguments)], function (self, args) {
+        return spread([this, all(Array.prototype.slice.call(arguments, 0))], function (self, args) {
             return callback.apply(self, args);
         });
     };
@@ -1505,7 +1505,7 @@ function all(promises) {
         if (!Array.isArray(arguments[0]) || arguments.length !== 1) {
             throw Error("All must be passed an array of promises.");
         }
-        
+
         var pendingCount = 0;
         var deferred = defer();
         array_reduce(promises, function (undefined, promise, index) {

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -1096,6 +1096,15 @@ describe("propagation", function () {
 });
 
 describe("all", function () {
+    it("rejects if not passed an array", function() {
+        var promise = Q.defer(),
+            willBeRejected = Q.all(promise);
+
+        willBeRejected.then(function() {
+            expect(willBeRejected.isRejected()).toBe(true);
+        });
+    });
+
     it("fulfills when passed an empty array", function () {
         return Q.all([]);
     });


### PR DESCRIPTION
Addresses #656.

This pull request adds a check to the Q.all() function to make sure it is being passed an array.  Will throw an error if not passed an array.  Also, small modification to promised function decorator, where all was being called with the arguments object, which now needs to be called with an actual array to avoid being rejected.