### PR TITLE
Fix small design-doc error

### DIFF
--- a/design/README.js
+++ b/design/README.js
@@ -81,7 +81,7 @@ maybeOneOneSecondLater().then(callback);
 /*
 This design has two weaknesses:
 
-- The first caller of the then method determines the callback that is used.
+- The last caller of the then method determines the callback that is used.
   It would be more useful if every registered callback were notified of
   the resolution.
 - If the callback is registered more than a second after the promise was


### PR DESCRIPTION
For example:
```javascript
var maybeOneOneSecondLater = function () {
    var callback;
    setTimeout(function () {
        callback(1);
    }, 1000);
    return {
        then: function (_callback) {
            callback = _callback;
        }
    };
};

var p = maybeOneOneSecondLater();
p.then(c1);
p.then(c2);
```
`c2` wins.