### PR TITLE
add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,31 @@
+{
+  "name": "q",
+  "main": "q.js",
+  "version": "1.1.2",
+  "homepage": "https://github.com/kriskowal/q",
+  "authors": [
+    "Kris Kowal <kris@cixar.com> (https://github.com/kriskowal)"
+  ],
+  "description": "A library for promises (CommonJS/Promises/A,B,D)",
+  "keywords": [
+    "q",
+    "promise",
+    "promises",
+    "promises-a",
+    "promises-aplus",
+    "deferred",
+    "future",
+    "async",
+    "fluent",
+    "browser",
+    "node"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
I tried installing q via bower, and it didn't work correctly with main-bower-files for gulp that copies out the main dependency to an output folder at build time.  This bower.json mostly just matches the content in package.json, but should make bower installs work better.  

You would still need to follow the steps here to make sure it gets picked up properly:
http://bower.io/docs/creating-packages/

