### PR TITLE
Add .npmignore to exclude unnecessary development files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,19 @@
+npm-debug.log
+CHANGES.html
+README.html
+.tmp
+q.min.js
+
+.coverage_data/
+.coverage_debug/
+cover_html/
+
+# IntelliJ IDEA project files
+.idea
+*.iml
+
+# Development files
+/benchmark/
+/spec/
+/.jshintrc
+/.travis.yml


### PR DESCRIPTION
I copied .gitignore as .npmignore and added a few development files and folders to be excluded from the npm package as they're unnecessary. Also removed node_modules as it's unnecessary as per npm's documentation.