### PR TITLE
Make sure Q is in a real Node environment

### DIFF
--- a/q.js
+++ b/q.js
@@ -157,13 +157,14 @@ var nextTick =(function () {
 
     if (typeof process === "object" &&
         process.toString() === '[object process]' && process.nextTick) {
-        // Node.js before 0.9. Note that some fake-Node environments, like the
-        // Mocha test runner, introduce a `process` global without a `nextTick`.
-        // In addition, some fake-Node environments like browserify expose a
-        // `process.nexTick` function that uses `setTimeout`. In this case we'd
-        // much rather use `setImmediate` because it is faster. To ensure we are
-        // in a real Node environment, doing process + '' should be
-        // '[object process]'.
+        // Ensure we are in a real Node environment, with a `process.nextTick`.
+        // To see through fake Node environments:
+        // * Mocha test runner - exposes a `process` global without a `nextTick`
+        // * Browserify - exposes a `process.nexTick` function that uses
+        //   `setTimeout`. In this case we'd rather use `setImmediate` because
+        //    it is faster. Browserify's `process.toString()` yields
+        //   '[object Object]', while in a real Node environment
+        //   `process.nextTick()` yields '[object process]'.
         isNodeJS = true;
 
         requestTick = function () {

--- a/q.js
+++ b/q.js
@@ -155,8 +155,8 @@ var nextTick =(function () {
         }
     };
 
-    if (typeof process === "object" && (process + '') === '[object process]' &&
-        process.nextTick) {
+    if (typeof process === "object" &&
+        process.toString() === '[object process]' && process.nextTick) {
         // Node.js before 0.9. Note that some fake-Node environments, like the
         // Mocha test runner, introduce a `process` global without a `nextTick`.
         // In addition, some fake-Node environments like browserify expose a

--- a/q.js
+++ b/q.js
@@ -155,9 +155,15 @@ var nextTick =(function () {
         }
     };
 
-    if (typeof process !== "undefined" && process.nextTick) {
+    if (typeof process === "object" && (process + '') === '[object process]' &&
+        process.nextTick) {
         // Node.js before 0.9. Note that some fake-Node environments, like the
         // Mocha test runner, introduce a `process` global without a `nextTick`.
+        // In addition, some fake-Node environments like browserify expose a
+        // `process.nexTick` function that uses `setTimeout`. In this case we'd
+        // much rather use `setImmediate` because it is faster. To ensure we are
+        // in a real Node environment, doing process + '' should be
+        // '[object process]'.
         isNodeJS = true;
 
         requestTick = function () {

--- a/q.js
+++ b/q.js
@@ -157,11 +157,11 @@ var nextTick =(function () {
 
     if (typeof process === "object" &&
         process.toString() === '[object process]' && process.nextTick) {
-        // Ensure we are in a real Node environment, with a `process.nextTick`.
+        // Ensure Q is in a real Node environment, with a `process.nextTick`.
         // To see through fake Node environments:
         // * Mocha test runner - exposes a `process` global without a `nextTick`
         // * Browserify - exposes a `process.nexTick` function that uses
-        //   `setTimeout`. In this case we'd rather use `setImmediate` because
+        //   `setTimeout`. In this case `setImmediate` is preferred because
         //    it is faster. Browserify's `process.toString()` yields
         //   '[object Object]', while in a real Node environment
         //   `process.nextTick()` yields '[object process]'.


### PR DESCRIPTION
This adds an additional check to ensure that the `process` global Q looks for is closer to the global that nodejs environments expose. This is in light of updates to `node-process` a process shim used by Browserify:

https://github.com/defunctzombie/node-process/

This library no longer uses `setImmediate` if it is available, it uses `setTimeout` out of the box. Because Browserify is getting so popular as a moduling system, I think it is wise to add this check, so Browserify user's get all the extra `setImmediate` juice they possibly can.

By default, Browserify will scan files for `process` usage and insert the global as needed. Most users won't read this, and if they do, they probably won't realize there is a pretty big performance penalty if this setting is left on. Turning it off will also mean that certain modules will no longer work. I think this solution is the best of both worlds: get the added performance and still use the `process` global if needed.

>When opts.detectGlobals is true, scan all files for process, global, __filename, and __dirname, defining as necessary. With this option npm modules are more likely to work but bundling takes longer. Default true.

The solution I proposed is really simple, but it does the t(r)ick. `toString`ing the `process` global in node yields: `'[object process]'`, while the `process` shim Browserify uses yields: `'[object Object]'`.

The module [detect-node](https://github.com/iliakan/detect-node) uses a similar method.