### PR TITLE
Favor window global over self global

### DIFF
--- a/q.js
+++ b/q.js
@@ -55,16 +55,20 @@
         }
 
     // <script>
-    } else if (typeof self !== "undefined") {
+    } else if (typeof window !== "undefined" || typeof self !== "undefined") {
+        // Prefer window over self for add-on scripts. Use self for
+        // non-windowed contexts.
+        var global = typeof window !== "undefined" ? window : self;
+
         // Get the `window` object, save the previous Q global
         // and initialize Q as a global.
-        var previousQ = self.Q;
-        self.Q = definition();
+        var previousQ = global.Q;
+        global.Q = definition();
 
         // Add a noConflict function so Q can be removed from the
         // global namespace.
-        self.Q.noConflict = function () {
-            self.Q = previousQ;
+        global.Q.noConflict = function () {
+            global.Q = previousQ;
             return this;
         };
 


### PR DESCRIPTION
So that Q can be used as a `<script>` in Firefox add-ons.
The self object does not refer to window and is immutable.

Fixes #631