### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,7 @@
     "mail": "kris@cixar.com",
     "url": "http://github.com/kriskowal/q/issues"
   },
-  "license": {
-    "type": "MIT",
-    "url": "http://github.com/kriskowal/q/raw/master/LICENSE"
-  },
+  "license": "MIT",
   "main": "q.js",
   "files": [
     "LICENSE",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/