### PR TITLE
Making `Q.set` and `Q.delete` chainable

### DIFF
--- a/q.js
+++ b/q.js
@@ -1148,9 +1148,11 @@ function fulfill(value) {
         },
         "set": function (name, rhs) {
             value[name] = rhs;
+            return value;
         },
         "delete": function (name) {
             delete value[name];
+            return value;
         },
         "post": function (name, args) {
             // Mark Miller proposes that post with no name should apply a

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -557,9 +557,19 @@ describe("promises for objects", function () {
             return Q(object)
             .set("a", 1)
             .then(function (result) {
-                expect(result).toBe(undefined);
+                expect(result).not.toBe(undefined);
+                expect(result).toBe(object);
                 expect(object.a).toBe(1);
             });
+        });
+
+        it("propagates the modified object", function () {
+            return Q({ foo: "bar" })
+                .set("foo", "baz")
+                .get("foo")
+                .then(function(value) {
+                    expect(value).toBe("baz");
+                });
         });
 
         it("propagates a rejection", function () {
@@ -585,10 +595,20 @@ describe("promises for objects", function () {
             .del("a")
             .then(function (result) {
                 expect("a" in object).toBe(false);
-                expect(result).toBe(void 0);
+                expect(result).not.toBe(undefined);
+                expect(result).toBe(object);
             }, function () {
                 expect("up").toBe("down");
             });
+        });
+
+        it("propagates the modified object", function () {
+            return Q({ foo: "bar" })
+                .delete("foo")
+                .get("foo")
+                .then(function(value) {
+                    expect(value).toBe(undefined);
+                });
         });
 
         it("propagates a rejection", function () {


### PR DESCRIPTION
When I was answering [this question in Stackoverflow](http://stackoverflow.com/q/30919307/1903116), I realized that we cannot do something like this

    Q({ foo: "bar" }).set("foo", "baz").then(console.log);

Because, `set` doesn't resolve with the modified object, so `console.log` would print `undefined`. Also, this limits the users from doing, something like this

    Q({ foo: "bar" }).set("foo", "baz").get("foo").then(console.log);

The intention of this PR is to make `set` and `delete` to resolve with the modified object, so that they can be chained in the promise flow.