### PR TITLE
Update q.js

### DIFF
--- a/q.js
+++ b/q.js
@@ -1918,6 +1918,9 @@ Promise.prototype.nfcall = function (/*...args*/) {
  */
 Q.nfbind =
 Q.denodeify = function (callback /*...args*/) {
+    if (callback === undefined) {
+        throw new Error('Q Cannot wrap an undefined function');
+    }
     var baseArgs = array_slice(arguments, 1);
     return function () {
         var nodeArgs = baseArgs.concat(array_slice(arguments));


### PR DESCRIPTION
nfbind/denodeify: Throw error when wrapping an undefined function. Leads to clearer error message/stack (instead of throwing error when using the resulting promised wrapped function.

Next step: I have the feeling this fix could also be applied to Q.nbind (https://github.com/kriskowal/q/blob/v1/q.js#L1938). I'll do it if this PR is accepted.