### PR TITLE
Q.any gives an error message from last rejected promise

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,4 @@
+ - Q.any gives an error message from the last rejected promise
  - Throw if callback supplied to "finally" is invalid (@grahamrhay)
 
 ## 1.4.1

--- a/q.js
+++ b/q.js
@@ -1625,10 +1625,9 @@ function any(promises) {
         function onRejected(err) {
             pendingCount--;
             if (pendingCount === 0) {
-                deferred.reject(new Error(
-                    "Q can't get fulfillment value from any promise, all " +
-                    "promises were rejected. Last error: " + err
-                ));
+                err.message = ("Q can't get fulfillment value from any promise, all " +
+                    "promises were rejected. Last error message: " + err.message);
+                deferred.reject(err);
             }
         }
         function onProgress(progress) {

--- a/q.js
+++ b/q.js
@@ -1622,12 +1622,12 @@ function any(promises) {
         function onFulfilled(result) {
             deferred.resolve(result);
         }
-        function onRejected() {
+        function onRejected(err) {
             pendingCount--;
             if (pendingCount === 0) {
                 deferred.reject(new Error(
                     "Q can't get fulfillment value from any promise, all " +
-                    "promises were rejected."
+                    "promises were rejected. Last error: " + err
                 ));
             }
         }

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -1218,7 +1218,7 @@ describe("any", function() {
           .then(function() {
               expect(promise.isRejected()).toBe(true);
               expect(promise.inspect().reason.message)
-              .toBe("Q can't get fulfillment value from any promise, all promises were rejected.");
+              .toBe("Q can't get fulfillment value from any promise, all promises were rejected. Last error: Error: Rejected");
           })
           .timeout(1000);
     }

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -1206,19 +1206,21 @@ describe("any", function() {
 
     function testReject(promises, deferreds) {
         var promise = Q.any(promises);
+        var expectedError = new Error('Rejected');
 
         for (var index = 0; index < deferreds.length; index++) {
             var deferred = deferreds[index];
             (function() {
-                deferred.reject(new Error('Rejected'));
+                deferred.reject(expectedError);
             })();
         }
 
         return Q.delay(250)
           .then(function() {
               expect(promise.isRejected()).toBe(true);
+              expect(promise.inspect().reason).toBe(expectedError);
               expect(promise.inspect().reason.message)
-              .toBe("Q can't get fulfillment value from any promise, all promises were rejected. Last error: Error: Rejected");
+              .toBe("Q can't get fulfillment value from any promise, all promises were rejected. Last error message: Rejected");
           })
           .timeout(1000);
     }


### PR DESCRIPTION
```
let p1 = makeHttpRequest(...);
let p2 = makeHttpRequest(...);
return Q.any([p1, p2]);
```

In the above case if both HTTP requests fail it would be useful to see the error message from one of them. The last is the most convenient.