### PR TITLE
Corrected mistake in design weakness explanation

### DIFF
--- a/design/README.js
+++ b/design/README.js
@@ -81,7 +81,7 @@ maybeOneOneSecondLater().then(callback);
 /*
 This design has two weaknesses: 
 
-- The first caller of the then method determines the callback that is used.
+- The last caller of the then method determines the callback that is used.
   It would be more useful if every registered callback were notified of
   the resolution.
 - If the callback is registered more than a second after the promise was


### PR DESCRIPTION
It is the *last* caller of the then method who determines which callback is used, not the *first* caller.