### PR TITLE
Fixes Q logo for documentup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 [![Build Status](https://secure.travis-ci.org/kriskowal/q.svg?branch=master)](http://travis-ci.org/kriskowal/q)
 
 <a href="http://promises-aplus.github.com/promises-spec">
-    <img src="http://kriskowal.github.io/q/q.png"
-         align="right" alt="Q logo" />
+    <img src="http://kriskowal.github.io/q/q.png" align="right" alt="Q logo" />
 </a>
 
 *This is Q version 1, from the `v1` branch in Git. This documentation applies to


### PR DESCRIPTION
The [documentation](http://documentup.com/kriskowal/q/) on documentup is rendering html attributes on the page. I believe this is because of how it is parsing the line break in the readme doc, which should be fixed by this PR.

![screenshot from 2015-12-09 02 46 52](https://cloud.githubusercontent.com/assets/1934719/11681990/9a22c5e2-9e1f-11e5-9a15-f1e5dafaace9.png)
