### PR TITLE
Allow nfbind bound function to handle missing args

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
  - Q.any gives an error message from the last rejected promise
  - Throw if callback supplied to "finally" is invalid (@grahamrhay)
+ - Allow the function created with nfbind to handle missing arguments
 
 ## 1.4.1
 

--- a/q.js
+++ b/q.js
@@ -268,6 +268,7 @@ function uncurryThis(f) {
 // http://jsperf.com/uncurrythis
 
 var array_slice = uncurryThis(Array.prototype.slice);
+var array_concat = uncurryThis(Array.prototype.concat);
 
 var array_reduce = uncurryThis(
     Array.prototype.reduce || function (callback, basis) {
@@ -343,6 +344,14 @@ var object_toString = uncurryThis(Object.prototype.toString);
 
 function isObject(value) {
     return value === Object(value);
+}
+
+// Pad an array value with nulls to the specified length.  Longer arrays are left alone.
+function padArrayTo(arry,len) {
+    if ( arry.length < len ) {
+        arry = array_concat(arry, new Array(len - arry.length));
+    }
+    return arry;
 }
 
 // generator related shims
@@ -1921,8 +1930,9 @@ Q.denodeify = function (callback /*...args*/) {
         throw new Error("Q can't wrap an undefined function");
     }
     var baseArgs = array_slice(arguments, 1);
+    var expectArgs = callback.length-baseArgs.length-1;
     return function () {
-        var nodeArgs = baseArgs.concat(array_slice(arguments));
+        var nodeArgs = baseArgs.concat(padArrayTo(array_slice(arguments),expectArgs));
         var deferred = defer();
         nodeArgs.push(deferred.makeNodeResolver());
         Q(callback).fapply(nodeArgs).fail(deferred.reject);

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -2343,6 +2343,15 @@ describe("node support", function () {
             });
         });
 
+        it("allows bound function to support missing arguments", function() {
+            return Q.nfbind(function (a, b, c, d, callback) {
+                callback(null, !d);
+            }).call({},1,2,3)
+            .then(function(nod) {
+                expect(nod).toBe(true);
+            });
+        });
+
     });
 
     describe("nbind", function () {


### PR DESCRIPTION
A common coding habit in javascript is to omit trailing arguments whose value is null.  Currently a function created via nfbind will not behave properly if used this way,   This patch allows the function to behave properly, by padding out any missing arguments with null values.