### PR TITLE
Remove (no stack) string for unhandledReasons 

### DIFF
--- a/q.js
+++ b/q.js
@@ -1066,7 +1066,7 @@ function trackRejection(promise, reason) {
     if (reason && typeof reason.stack !== "undefined") {
         unhandledReasons.push(reason.stack);
     } else {
-        unhandledReasons.push("(no stack) " + reason);
+        unhandledReasons.push(reason);
     }
 }
 


### PR DESCRIPTION
The string in the console makes it hard to debug since the object will not be printed anymore.