### PR TITLE
Log Error when window.DEBUG is set to true

### DIFF
--- a/q.js
+++ b/q.js
@@ -681,6 +681,9 @@ function promise(resolver) {
     try {
         resolver(deferred.resolve, deferred.reject, deferred.notify);
     } catch (reason) {
+        if (window.DEBUG) {
+            console.error(reason);
+        }
         deferred.reject(reason);
     }
     return deferred.promise;


### PR DESCRIPTION
I found this really helpful when debugging un-done promise that are swallowing errors.