### PR TITLE
Reduce memory usage when longStackSupport is disabled

### DIFF
--- a/q.js
+++ b/q.js
@@ -597,7 +597,12 @@ function defer() {
 
     function become(newPromise) {
         resolvedPromise = newPromise;
-        promise.source = newPromise;
+
+        if (Q.longStackSupport && hasStacks) {
+            // Only hold a reference to the new promise if long stacks
+            // are enabled to reduce memory usage
+            promise.source = newPromise;
+        }
 
         array_reduce(messages, function (undefined, message) {
             Q.nextTick(function () {


### PR DESCRIPTION
While analyzing a heapdump from a server that was consuming a lot of memory, I noticed a lot of reference to promise.source.  I looked at the code and it appears that the value is only used when longStackSupport is enabled (which was not enabled for me).

This change is a small optimization to reduce memory usage when longStackSupport is disabled.