### PR TITLE
add leading semi colon to prevent concat error

### DIFF
--- a/q.js
+++ b/q.js
@@ -26,7 +26,7 @@
  *
  */
 
-(function (definition) {
+;(function (definition) {
     "use strict";
 
     // This file will function properly as a <script> tag, or a module


### PR DESCRIPTION
just to prevent errors introduced by concatenation like this
```javascript
(function(){...})()(function(){...})()
```