### PR TITLE
Long stack improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
  - Q.any gives an error message from the last rejected promise
  - Throw if callback supplied to "finally" is invalid (@grahamrhay)
+ - Long stack trace improvements, can now construct long stack traces
+   across rethrows.
 
 ## 1.4.1
 

--- a/q.js
+++ b/q.js
@@ -394,7 +394,8 @@ function makeStackTraceLong(error, promise) {
         stacks.unshift(error.stack);
 
         var concatedStacks = stacks.join("\n" + STACK_JUMP_SEPARATOR + "\n");
-        error.stack = filterStackString(concatedStacks);
+        var stack = filterStackString(concatedStacks);
+        object_defineProperty(error, "stack", {value: stack, configurable: true});
     }
 }
 

--- a/q.js
+++ b/q.js
@@ -522,6 +522,12 @@ Q.nextTick = nextTick;
  */
 Q.longStackSupport = false;
 
+/**
+ * The counter is used to determine the stopping point for building
+ * long stack traces. In makeStackTraceLong we walk backwards through
+ * the linked list of promises, only stacks which were created before
+ * the rejection are concatenated.
+ */
 var longStackCounter = 1;
 
 // enable long stacks if Q_DEBUG is set

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -2758,6 +2758,77 @@ describe("stack trace formatting", function () {
     });
 });
 
+describe("long stack traces", function () {
+    beforeEach(function () {
+        Q.longStackSupport = true;
+    });
+
+    afterEach(function () {
+        Q.longStackSupport = false;
+    });
+
+    it("include all the calling functions", function () {
+        function func1() {
+            return Q().then(function () { return func2(); })
+                .catch(function rethrow (err) {throw err;});
+        }
+        function func2() {
+            return new Q.Promise(function (resolve, reject) {
+                func3().then(resolve, reject);
+            });
+        }
+        function func3() {
+            return new Q.Promise(function (resolve, reject) {
+                setTimeout(function () {
+                    reject(new Error(REASON));
+                }, 0);
+            });
+        }
+
+        return func1()
+        .catch(function (err) {
+            expect(err.stack).toMatch(/^Error: this is not an error/);
+            expect(err.stack).toMatch(/func3(.|\n)*func2(.|\n)*func1/);
+        });
+    });
+
+    it("does not duplicate lines when rethrowing an error", function () {
+        function func1() {
+            return func2()
+                .catch(function rethrow (err) {throw err;})
+                .catch(function rethrow (err) {throw err;});
+        }
+        function func2() {
+            return Q().then(function () {
+                return func3();
+            });
+        }
+        function func3() {
+            return Q.reject(new Error(REASON));
+        }
+
+        return func1()
+        .catch(function (err) {
+            expect(err.stack).toMatch(/^Error: this is not an error/);
+            expect(err.stack).toMatch(/func3(.|\n)*func2(.|\n)*func1/);
+            expect(err.stack.match(/func1/g).length).toBe(1);
+            expect(err.stack.match(/func2/g).length).toBe(1);
+            expect(err.stack.match(/func3/g).length).toBe(1);
+        });
+    });
+
+    it("does not add visible properties to thrown errors", function () {
+        return Q().then(function () { throw new Error(REASON); })
+        .catch(function (err) {
+            var keys = [];
+            for (var key in err) {
+                keys.push(key);
+            }
+            expect(keys.length).toBe(0);
+        });
+    });
+});
+
 describe("possible regressions", function () {
 
     describe("gh-9", function () {

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -2769,8 +2769,7 @@ describe("long stack traces", function () {
 
     it("include all the calling functions", function () {
         function func1() {
-            return Q().then(function () { return func2(); })
-                .catch(function rethrow (err) {throw err;});
+            return Q().then(function () { return func2(); });
         }
         function func2() {
             return new Q.Promise(function (resolve, reject) {
@@ -2787,7 +2786,6 @@ describe("long stack traces", function () {
 
         return func1()
         .catch(function (err) {
-            expect(err.stack).toMatch(/^Error: this is not an error/);
             expect(err.stack).toMatch(/func3(.|\n)*func2(.|\n)*func1/);
         });
     });
@@ -2809,11 +2807,8 @@ describe("long stack traces", function () {
 
         return func1()
         .catch(function (err) {
-            expect(err.stack).toMatch(/^Error: this is not an error/);
             expect(err.stack).toMatch(/func3(.|\n)*func2(.|\n)*func1/);
             expect(err.stack.match(/func1/g).length).toBe(1);
-            expect(err.stack.match(/func2/g).length).toBe(1);
-            expect(err.stack.match(/func3/g).length).toBe(1);
         });
     });
 


### PR DESCRIPTION
When longStackSupport is enabled count each stack trace that is created.

While following the promise chain keep appending stacks as long as they are older than the source.
