### PR TITLE
Protect access to `e.stack` with a `try/catch`

### DIFF
--- a/q.js
+++ b/q.js
@@ -83,7 +83,9 @@ var hasStacks = false;
 try {
     throw new Error();
 } catch (e) {
-    hasStacks = !!e.stack;
+    try {
+        hasStacks = !!e.stack;
+    } catch (ex) {}
 }
 
 // All code after this point will be filtered from stack traces reported


### PR DESCRIPTION
Fixes kriskowal/q#796