### PR TITLE
Add CDNJS badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://secure.travis-ci.org/kriskowal/q.svg?branch=master)](http://travis-ci.org/kriskowal/q)
+[![CDNJS](https://img.shields.io/cdnjs/v/q.js.svg)](https://cdnjs.com/libraries/q.js)
 
 <a href="http://promises-aplus.github.com/promises-spec">
     <img src="http://kriskowal.github.io/q/q.png" align="right" alt="Q logo" />


### PR DESCRIPTION
This will add the badge to show its version on CDNJS and also link to its page on CDNJS!