### PR TITLE
Adds a `Q.getUnhandledRejectionValues()` function

### DIFF
--- a/q.js
+++ b/q.js
@@ -1118,6 +1118,12 @@ Q.getUnhandledReasons = function () {
     return unhandledReasons.slice();
 };
 
+Q.getUnhandledRejectionValues = function () {
+    return unhandledRejections.map(function(rejectedPromise) {
+      return rejectedPromise.exception;
+    });
+};
+
 Q.stopUnhandledRejectionTracking = function () {
     resetUnhandledRejections();
     trackUnhandledRejections = false;

--- a/q.js
+++ b/q.js
@@ -1119,7 +1119,7 @@ Q.getUnhandledReasons = function () {
 };
 
 Q.getUnhandledRejectionValues = function () {
-    return unhandledRejections.map(function(rejectedPromise) {
+    return array_map(unhandledRejections, function(rejectedPromise) {
       return rejectedPromise.exception;
     });
 };

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -2976,4 +2976,21 @@ describe("unhandled rejection reporting", function () {
 
         expect(Q.getUnhandledReasons()).toEqual([]);
     });
+
+    describe("getUnhandledRejectionValues", function () {
+      it("contains a reference to the rejection value", function () {
+          var rejectionRef = { some: "reason" };
+          Q.reject(rejectionRef);
+
+          expect(Q.getUnhandledRejectionValues()).toEqual([rejectionRef]);
+      });
+
+      it("resets after calling `Q.resetUnhandledRejections`", function () {
+          Q.reject("a reason");
+
+          Q.resetUnhandledRejections();
+          expect(Q.getUnhandledRejectionValues()).toEqual([]);
+      });
+    });
+
 });


### PR DESCRIPTION
The purpose of `Q.getUnhandledRejectionValues()` is for debug access to actual rejection values, because `Q.getUnhandledReasons()` only provides a string representation of rejections. And that string representation can often be pretty useless, particularly when code is intentionally or accidentally rejecting non-error values (I've seen legacy CoffeeScript do that a bunch due to automatic returns). Also when live debugging a problem, having an actual rejection reference lets you inspect deeper, like if you set custom properties on an error, etc.

Some examples:

```
Q.reject('foobar');
// => Promise {exception: "foobar"}

Q.getUnhandledReasons()
// => ["(no stack) foobar"]

Q.getUnhandledRejectionValues()
// => ["foobar"]
```

```
Q.reject({ foo: "bar" })

Q.getUnhandledReasons();
// => ["(no stack) [object Object]"]

Q.getUnhandledRejectionValues()
// => { foo: "bar" }
```

```
CustomClass = function () {}
Q.reject(new CustomClass)

Q.getUnhandledReasons();
// => ["(no stack) [object Object]"]

Q.getUnhandledRejectionValues()
// => CustomClass instance
```

I've added a couple basic tests for `Q.getUnhandledRejectionValues()`, ensured `npm test` was green, and ran q-spec.html in a few browsers (latest Chrome, Firefox, and Safari).
