### PR TITLE
Improve unhandled rejection reason strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+Next minor change:
+  - Ensure that unhandled rejection strings created from actual `Error`s in all modern browsers include the error type and message (in addition to the stack).
+  - Add a hook, `Q.customizeRejectionString` which can be used for developers to customize how rejection values are string-ified.
+
 ## 1.5.0
 
  - Q.any gives an error message from the last rejected promise

--- a/q.js
+++ b/q.js
@@ -1085,6 +1085,12 @@ function trackRejection(promise, reason) {
     unhandledRejections.push(promise);
     var rejectionString = reason + "";
 
+    // Public hook to allow for custom tweaking of unhandled rejection string (note, stack
+    // will be appended afterwards by code below)
+    if (Q.customizeRejectionString) {
+        rejectionString = Q.customizeRejectionString(reason);
+    }
+
     if (reason && typeof reason.stack !== "undefined") {
         // If the error's stack string already includes the error type and message, don't double it up
         // (since only a few browsers do that, e.g. Chrome vs Firefox). Otherwise, manually append

--- a/q.js
+++ b/q.js
@@ -1083,10 +1083,19 @@ function trackRejection(promise, reason) {
     }
 
     unhandledRejections.push(promise);
+    var rejectionString = reason + "";
+
     if (reason && typeof reason.stack !== "undefined") {
-        unhandledReasons.push(reason.stack);
+        // If the error's stack string already includes the error type and message, don't double it up
+        // (since only a few browsers do that, e.g. Chrome vs Firefox). Otherwise, manually append
+        // the error type and message to the stack string
+        if (reason.stack.slice && reason.stack.slice(0, rejectionString.length) === rejectionString) {
+            unhandledReasons.push(reason.stack);
+        } else {
+            unhandledReasons.push(rejectionString + "\n" + reason.stack);
+        }
     } else {
-        unhandledReasons.push("(no stack) " + reason);
+        unhandledReasons.push("(no stack) " + rejectionString);
     }
 }
 

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -2948,9 +2948,18 @@ describe("unhandled rejection reporting", function () {
 
     it("reports a stack trace", function () {
         var error = new Error("a reason");
+        var firstLineOfStack = error.stack ? error.stack.split('\n')[0] : undefined;
+        var expectedStack;
+
         Q.reject(error);
 
-        expect(Q.getUnhandledReasons()).toEqual([error.stack]);
+        if (firstLineOfStack && firstLineOfStack.indexOf('a reason') >= 0) {
+            expectedStack = error.stack;
+        } else {
+            // For browsers like firefox that don't include the error type/message in the stack
+            expectedStack = "Error: a reason\n" + error.stack;
+        }
+        expect(Q.getUnhandledReasons()).toEqual([expectedStack]);
     });
 
     it("doesn't let you mutate the internal array", function () {

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -2988,7 +2988,7 @@ describe("unhandled rejection reporting", function () {
 
     describe("Q.customizeRejectionString", function() {
         beforeEach(function() {
-    		var spy = jasmine.createSpy();
+            var spy = jasmine.createSpy();
             Q.customizeRejectionString = spy;
         })
 
@@ -2996,27 +2996,27 @@ describe("unhandled rejection reporting", function () {
             delete Q.customizeRejectionString;
         })
 
-    	it("is called if it exists", function () {
+        it("is called if it exists", function () {
             Q.reject('no reason');
-    		expect(Q.customizeRejectionString).toHaveBeenCalled();
-    	});
+            expect(Q.customizeRejectionString).toHaveBeenCalled();
+         });
 
-    	it("is called with the rejection reason", function () {
+        it("is called with the rejection reason", function () {
             Q.reject('no reason 2');
-    		expect(Q.customizeRejectionString).toHaveBeenCalledWith('no reason 2');
-    	});
+            expect(Q.customizeRejectionString).toHaveBeenCalledWith('no reason 2');
+        });
 
-    	it("its result changes what is stored in the unhandled reasons array", function () {
+        it("its result changes what is stored in the unhandled reasons array", function () {
             Q.customizeRejectionString.andReturn('changed reason');
             Q.reject('no reason 3');
-        expect(Q.getUnhandledReasons()).toEqual(['(no stack) changed reason']);
-    	});
+            expect(Q.getUnhandledReasons()).toEqual(['(no stack) changed reason']);
+        });
 
-    	it("its does't remove the stack when an error is rejected", function () {
+        it("its does't remove the stack when an error is rejected", function () {
             var fakeError = new Error('fake errror');
             Q.customizeRejectionString.andReturn('Even fancier fake error message');
             Q.reject(fakeError);
-        expect(Q.getUnhandledReasons()[0]).toEqual('Even fancier fake error message' + '\n' + fakeError.stack);
-    	});
+            expect(Q.getUnhandledReasons()[0]).toEqual('Even fancier fake error message' + '\n' + fakeError.stack);
+        });
     });
 });

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -2985,4 +2985,38 @@ describe("unhandled rejection reporting", function () {
 
         expect(Q.getUnhandledReasons()).toEqual([]);
     });
+
+    describe("Q.customizeRejectionString", function() {
+        beforeEach(function() {
+    		var spy = jasmine.createSpy();
+            Q.customizeRejectionString = spy;
+        })
+
+        afterEach(function() {
+            delete Q.customizeRejectionString;
+        })
+
+    	it("is called if it exists", function () {
+            Q.reject('no reason');
+    		expect(Q.customizeRejectionString).toHaveBeenCalled();
+    	});
+
+    	it("is called with the rejection reason", function () {
+            Q.reject('no reason 2');
+    		expect(Q.customizeRejectionString).toHaveBeenCalledWith('no reason 2');
+    	});
+
+    	it("its result changes what is stored in the unhandled reasons array", function () {
+            Q.customizeRejectionString.andReturn('changed reason');
+            Q.reject('no reason 3');
+        expect(Q.getUnhandledReasons()).toEqual(['(no stack) changed reason']);
+    	});
+
+    	it("its does't remove the stack when an error is rejected", function () {
+            var fakeError = new Error('fake errror');
+            Q.customizeRejectionString.andReturn('Even fancier fake error message');
+            Q.reject(fakeError);
+        expect(Q.getUnhandledReasons()[0]).toEqual('Even fancier fake error message' + '\n' + fakeError.stack);
+    	});
+    });
 });


### PR DESCRIPTION
This PR improves the strings that end up in `Q.getUnhandledReasons()` two different ways:
  1. Ensure that unhandled rejection strings created from actual `Error`s in all modern browsers include the error type and message (in addition to the stack).
  1. Add a hook, `Q.customizeRejectionString` which can be used for developers to customize how rejection values are string-ified.

For 1, the problem I ran into was that rejection reasons inside `Q.getUnhandledReasons()` didn't actually contain the error type and message and they _only_ had the error stack in some browsers. This is because Q uses `error.stack` and the output of `error.stack` in Firefox and Safari is different than I expected. For example:

```js
try { throw new Error('Test error') } catch (e) { console.log(e.stack) }

// in Chrome (and similar in Edge/IE)...
// => Error: Test error
// =>      at <anonymous>:1:13

// but in Firefox and Safari the error type and message isn't included, and you get ...
// => @debugger eval code:1:13
```

Not only was that surprising to me, but it makes tracking down the unhandled rejections that real users run into in Firefox & Safari much harder to debug since the error message is missing. So in these changes I detect when `error.stack` is missing the error type & message and manually insert it to the beginning of the string that ends up in `Q.getUnhandledReasons()`:

**Before in Firefox**
```js
Q.reject(new Error('faux error'));
Q.getUnhandledReasons()[0];
// => @debugger eval code:1:10
```

**After in Firefox**
```js
Q.reject(new Error('faux error'));
Q.getUnhandledReasons()[0];
// => Error: faux error
// => @debugger eval code:1:10
```

---

While 1 is an improvement, it doesn't help when some code rejects an object, primitive, or custom instance (which don't have a stack strace). So 2 adds the `Q.customizeRejectionString` hook which can allow developers to customize unhandled rejection strings themselves. For example:

```js
CustomClass = function () {}
Q.reject(new CustomClass)

Q.getUnhandledReasons()[0];
// => (no stack) [object Object]

// But if we add this...
Q.customizeRejectionString = function(reason) {
  if (reason.constructor && reason.constructor.name) {
    return 'CUSTOM: ' + reason.constructor.name;
  } 
};

Q.reject(new CustomClass)

Q.getUnhandledReasons()[1]
//=> (no stack) CUSTOM: CustomClass
```

Or some `JSON.stringify`-ing...

```js
Q.customizeRejectionString = function(reason) {
  if (!(reason instanceof Error) && typeof reason === 'object') {
    return JSON.stringify(reason)
  } 
};

Q.reject({ foo: 'bar' });
Q.getUnhandledReasons()[0]
// => (no stack) {"foo":"bar"}
```

I know that we ideally _should_ only be rejecting JS errors and not other values, but we're far from perfect. We have plenty of code written before we had a better understanding of promises, have legacy CoffeeScript where automatic returns can get in the way, need to do a better job of teaching developers about promise foot-guns, etc. So `Q.customizeRejectionString` could a big help for us to track down some of these problematic promise chains.

---

I should also mention that I've added a some tests for these changes, ensured npm test was green, and ran q-spec.html in a few browsers (latest Chrome, Firefox, and Safari).

ps: This PR and https://github.com/kriskowal/q/pull/816 came out of me trying to provide better tooling to other ([HubSpot](http://product.hubspot.com/)) developers trying to track down and fix various unhandled rejections. On our production apps we have code that polls `Q.getUnhandledReasons()` every 5 seconds, sending anything there to a JS error tracking service. While that helped us track down several  problematic promise chains, there still were many unhandled "errors" that were useless. And I'm hoping these changes will help track those down.