### PR TITLE
spec: don't use domain.dispose()

### DIFF
--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -2633,9 +2633,6 @@ if (typeof require === "function") {
             beforeEach(function () {
                 d = domain.create();
             });
-            afterEach(function() {
-                d.dispose();
-            });
 
             it("should work for non-promise async inside a promise handler",
                function (done) {


### PR DESCRIPTION
`domain.dispose()` has been emitting a runtime deprecation warning since 2013 (!) and is removed in Node 9. There is no reason to call it for these tests, so the call can safely be removed.