### PR TITLE
Bugs/exit on jasmine failure rebase #757

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+## 1.5.x
+ - Make npm test fail if jasmine-node throws (@bruun)
 
 ## 1.5.1
 

--- a/package.json
+++ b/package.json
@@ -48,14 +48,14 @@
     "grunt": "~0.4.1",
     "grunt-cli": "~0.1.9",
     "grunt-contrib-uglify": "~0.9.1",
-    "jasmine-node": "1.11.0",
+    "jasmine-node": "1.14.5",
     "jshint": "~2.1.9",
     "matcha": "~0.2.0",
     "opener": "*",
     "promises-aplus-tests": "1.x"
   },
   "scripts": {
-    "test": "npm ls -s && jasmine-node spec && promises-aplus-tests spec/aplus-adapter && npm run -s lint",
+    "test": "npm ls -s && jasmine-node --captureExceptions spec && promises-aplus-tests spec/aplus-adapter && npm run -s lint",
     "test-browser": "opener spec/q-spec.html",
     "benchmark": "matcha",
     "lint": "jshint q.js",


### PR DESCRIPTION
via @ bruun 
```
While working on writing some new (failing) tests,
npm test continued to report success.
If you had a syntax error in the spec file that made
jasmine-node unable to parse it, it would fail silently
and continue to promises-aplus-tests.

Adding --captureExceptions makes sure it exits when
an exception is thrown.

Also bumped the jasmine-node dependency to the latest version.
```

- Original PR https://github.com/kriskowal/q/pull/757