### PR TITLE
Fixed use of Q#any and added test.

### DIFF
--- a/q.js
+++ b/q.js
@@ -1665,7 +1665,9 @@ function any(promises) {
 }
 
 Promise.prototype.any = function () {
-    return any(this);
+    return this.then(function(values) {
+        return any(values);
+    });
 };
 
 /**

--- a/spec/q-spec.js
+++ b/spec/q-spec.js
@@ -1421,6 +1421,13 @@ describe("any", function() {
           );
     });
 
+    it("fulfills when called from the prototype", function() {
+        return Q(["a", "b"])
+          .any()
+          .then(function(result) {
+              expect(result).toEqual("a")
+          })
+    })
 });
 
 describe("allSettled", function () {


### PR DESCRIPTION
`Q#any` (`.any` on a promise instance) previously would never resolve due to `any` requiring its parameter to be an array.