### PR TITLE
add tapCatch method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## 1.5.2
+- Introduces the `tapCatch` method to promises, which peeks error
+   passing through without actually catching it.
 
 ## 1.5.1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "q",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A library for promises (CommonJS/Promises/A,B,D)",
   "homepage": "https://github.com/kriskowal/q",
   "author": "Kris Kowal <kris@cixar.com> (https://github.com/kriskowal)",

--- a/q.js
+++ b/q.js
@@ -939,6 +939,26 @@ Promise.prototype.tap = function (callback) {
 };
 
 /**
+ * Works almost like "finally", but ONLY called for rejections.
+ * Convenience method for reacting to errors without handling them with promises.
+ * Useful for logging errors.
+ * Callback may return a promise that will be awaited for.
+ * @param {Function} callback
+ * @returns {Q.Promise}
+ * @example
+ * doSomething()
+ *   .tapCatch(console.error)
+ *   .catch(...);
+ */
+Promise.prototype.tapCatch = function (callback) {
+    callback = Q(callback);
+
+    return this["catch"](function (exception) {
+        return callback.fcall(exception).thenReject(exception);
+    });
+};
+
+/**
  * Registers an observer on a promise.
  *
  * Guarantees:


### PR DESCRIPTION
This is something I found useful from bluebird. But I'd stay with Q, which IMO is more comfortable to use. Pretty straight forward implementation, so are the the test cases. Tests passed with Chrome60, FF52, Safari(7 failed as 1.5.1) and IE11 (4 failed as 1.5.1).

Note I'm not sure about the new version `1.5.2`. According to the contributing guidelines, new feature should bump the minor version number?